### PR TITLE
Reset discussion time

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -12,6 +12,8 @@ endDiscussion: '{symbol} End discussion'
 endingDiscussion: 'Stopping {symbol}'
 resumeDiscussion: '{symbol} Resume discussion'
 resumingDiscussion: 'Resuming {symbol}'
+resetDiscussion: '{symbol} Reset discussion'
+resettingDiscussion: 'Resetting {symbol}'
 
 # Discussion duration badge
 discussionOngoing: 'Ongoing'

--- a/i18n/it.yml
+++ b/i18n/it.yml
@@ -11,6 +11,8 @@ endDiscussion: '{symbol} Termina'
 endingDiscussion: 'Interruzione... {symbol}'
 resumeDiscussion: '{symbol} Riprendi'
 resumingDiscussion: 'Riavvio in corso {symbol}'
+resetDiscussion: '{symbol} Azzera timer'
+resettingDiscussion: 'Azzeramento... {symbol}'
 
 # Discussion duration badge
 discussionOngoing: 'In corso'

--- a/src/LeanCoffeeBase.ts
+++ b/src/LeanCoffeeBase.ts
@@ -20,4 +20,6 @@ export class LeanCoffeeBase {
     this.boardStorage = new BoardStorage();
     this.cardStorage = new CardStorage();
   }
+
+  isRunningInProduction = (): boolean => (process.env.NODE_ENV as Environment) === 'production';
 }

--- a/src/LeanCoffeeDiscussionUI.ts
+++ b/src/LeanCoffeeDiscussionUI.ts
@@ -24,7 +24,7 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeBase {
 
   constructor({ w, config }: LeanCoffeeBaseParams) {
     super({ w, config });
-    this.t = w.TrelloPowerUp.iframe({ localization: I18nConfig });
+    this.t = w.TrelloPowerUp.iframe({ localization: I18nConfig, helpfulStacks: !this.isRunningInProduction() });
 
     this.badges = this.w.document.querySelector('.badges');
     this.badgeElapsed = this.w.document.querySelector('.badge-elapsed');
@@ -159,7 +159,6 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeBase {
   toggleBadges = (visible: boolean): void => {
     this.badges.style.display = visible ? 'grid' : 'none';
   };
-
 
   toggleVoting = (visible: boolean): void => {
     this.voting.forEach((element) => {

--- a/src/LeanCoffeePowerUp.ts
+++ b/src/LeanCoffeePowerUp.ts
@@ -172,6 +172,20 @@ class LeanCoffeePowerUp extends LeanCoffeeBase {
             );
           }
         }];
+
+        if (await this.discussion.hasEverBeenDiscussed(t)) {
+          items.push({
+            text: t.localizeKey('resetDiscussion', { symbol: '↺' }), // ANTICLOCKWISE OPEN CIRCLE ARROW
+            callback: async (t2: Trello.PowerUp.IFrame): Promise<void> => {
+              await this.discussion.reset(t2);
+              await t2.closePopup();
+              await this.discussion.cardStorage.saveDiscussionButtonLabel(
+                t2,
+                t2.localizeKey('resettingDiscussion', { symbol: '↺' }) // ANTICLOCKWISE OPEN CIRCLE ARROW
+              );
+            }
+          });
+        }
     }
 
     return t.popup({

--- a/src/LeanCoffeePowerUp.ts
+++ b/src/LeanCoffeePowerUp.ts
@@ -197,7 +197,8 @@ class LeanCoffeePowerUp extends LeanCoffeeBase {
   start(): void {
     const trelloPlugin = this.t.initialize(
       CapabilityHandlers(this), {
-        localization: I18nConfig
+        localization: I18nConfig,
+        helpfulStacks: !this.isRunningInProduction()
       }
     ) as Trello.PowerUp.Plugin;
 

--- a/src/LeanCoffeeSettings.ts
+++ b/src/LeanCoffeeSettings.ts
@@ -4,17 +4,15 @@ import { LeanCoffeeBase, LeanCoffeeBaseParams } from './LeanCoffeeBase';
 import { I18nConfig } from './utils/I18nConfig';
 
 class LeanCoffeeSettings extends LeanCoffeeBase {
-  isProduction: boolean;
   t: Trello.PowerUp.IFrame;
 
   constructor({ w, config }: LeanCoffeeBaseParams) {
     super({ w, config });
-    this.t = w.TrelloPowerUp.iframe({ localization: I18nConfig });
-    this.isProduction = process.env.NODE_ENV === 'production';
+    this.t = w.TrelloPowerUp.iframe({ localization: I18nConfig, helpfulStacks: !this.isRunningInProduction() });
   }
 
   init(): void {
-    if (!this.isProduction) {
+    if (!this.isRunningInProduction()) {
       (this.w.document.querySelector('.dev-only') as HTMLElement).style.display = 'block';
       this.w.document.getElementById('showData').addEventListener('click', this.showData.bind(this));
       this.w.document.getElementById('wipeData').addEventListener('click', this.wipeData.bind(this));
@@ -26,18 +24,18 @@ class LeanCoffeeSettings extends LeanCoffeeBase {
     });
   }
 
-  showData = (evt: Event): void => {
+  showData = async (evt: Event): Promise<void> => {
     evt.preventDefault();
-    if (this.isProduction) { return; }
+    if (this.isRunningInProduction()) { return; }
 
-    Debug.showData(this.t);
+    await Debug.showData(this.t);
   };
 
-  wipeData = (evt: Event): void => {
+  wipeData = async (evt: Event): Promise<void> => {
     evt.preventDefault();
-    if (this.isProduction) { return; }
+    if (this.isRunningInProduction()) { return; }
 
-    Debug.wipeData(this.t, this.cardStorage, this.boardStorage);
+    await Debug.wipeData(this.t, this.cardStorage, this.boardStorage);
   };
 }
 

--- a/src/popups/LeanCoffeePopupBase.ts
+++ b/src/popups/LeanCoffeePopupBase.ts
@@ -9,9 +9,11 @@ export class LeanCoffeePopupBase {
   t: Trello.PowerUp.IFrame;
 
   constructor({ w }: LeanCoffeePopupBaseParams) {
-    this.t = w.TrelloPowerUp.iframe();
+    this.t = w.TrelloPowerUp.iframe({ helpfulStacks: !this.isRunningInProduction() });
     this.w = w;
   }
+
+  isRunningInProduction = (): boolean => (process.env.NODE_ENV as Environment) === 'production';
 
   toggleFields(cssSelector: string, key: string): void {
     const elements: NodeListOf<HTMLElement> = this.w.document.querySelectorAll(cssSelector);

--- a/src/utils/Discussion.ts
+++ b/src/utils/Discussion.ts
@@ -37,6 +37,11 @@ class Discussion {
     return ['ONGOING', 'PAUSED'].includes(boardStatus) && cardId !== t.getContext().card;
   };
 
+  hasEverBeenDiscussed = async (t: Trello.PowerUp.IFrame): Promise<boolean> => {
+    const cardStatus = await this.cardStorage.getDiscussionStatus(t);
+    return cardStatus !== undefined;
+  };
+
   hasNotBeenArchived = async (t: Trello.PowerUp.IFrame, cardId: string): Promise<boolean> => {
     const allCards = await t.cards('id', 'name');
     return !!allCards.find((card) => card.id === cardId);
@@ -128,6 +133,16 @@ class Discussion {
       ]);
     } catch (err) {
       throw new Error(err);
+    }
+  };
+
+  reset = async (t: Trello.PowerUp.IFrame): Promise<void> => {
+    if (await this.hasEverBeenDiscussed(t)) {
+      await this.cardStorage.deleteMultiple(t, [
+        CardStorage.DISCUSSION_STATUS,
+        CardStorage.DISCUSSION_ELAPSED,
+        CardStorage.DISCUSSION_THUMBS
+      ], t.getContext().card);
     }
   };
 }


### PR DESCRIPTION
## Context
#38 

## Changes
- added a "Reset" item in the discussion menu to remove discussion information from a card (except the number of votes)
- added an initialisation option for the power-up and all child iframes, which should provide more [helpful error stacks](https://developer.atlassian.com/cloud/trello/guides/power-ups/topics/#troubleshooting) during development