### PR TITLE
Tweak analytics

### DIFF
--- a/assets/umami-2.18.0-debug.js
+++ b/assets/umami-2.18.0-debug.js
@@ -1,0 +1,235 @@
+(function () {
+    'use strict';
+
+    (window => {
+        const {
+            screen: { width, height },
+            navigator: { language, doNotTrack: ndnt, msDoNotTrack: msdnt },
+            location,
+            document,
+            history,
+            top,
+            doNotTrack,
+        } = window;
+        const { currentScript, referrer } = document;
+        if (!currentScript) return;
+
+        const { hostname, href, origin } = location;
+        const localStorage = href.startsWith('data:') ? undefined : window.localStorage;
+
+        const _data = 'data-';
+        const _false = 'false';
+        const _true = 'true';
+        const attr = currentScript.getAttribute.bind(currentScript);
+        const website = attr(_data + 'website-id');
+        const hostUrl = attr(_data + 'host-url');
+        const beforeSend = attr(_data + 'before-send');
+        const tag = attr(_data + 'tag') || undefined;
+        const autoTrack = attr(_data + 'auto-track') !== _false;
+        const dnt = attr(_data + 'do-not-track') === _true;
+        const excludeSearch = attr(_data + 'exclude-search') === _true;
+        const excludeHash = attr(_data + 'exclude-hash') === _true;
+        const domain = attr(_data + 'domains') || '';
+        const domains = domain.split(',').map(n => n.trim());
+        const host =
+            hostUrl || '' || currentScript.src.split('/').slice(0, -1).join('/');
+        const endpoint = `${host.replace(/\/$/, '')}/api/send`;
+        const screen = `${width}x${height}`;
+        const eventRegex = /data-umami-event-([\w-_]+)/;
+        const eventNameAttribute = _data + 'umami-event';
+        const delayDuration = 300;
+
+        /* Helper functions */
+
+        const getPayload = () => ({
+            website,
+            screen,
+            language,
+            title: document.title,
+            hostname,
+            url: currentUrl,
+            referrer: currentRef,
+            tag,
+            id: identity ? identity : undefined,
+        });
+
+        const hasDoNotTrack = () => {
+            const dnt = doNotTrack || ndnt || msdnt;
+            return dnt === 1 || dnt === '1' || dnt === 'yes';
+        };
+
+        /* Event handlers */
+
+        const handlePush = (_state, _title, url) => {
+            if (!url) return;
+
+            currentRef = currentUrl;
+            currentUrl = new URL(url, location.href);
+
+            if (excludeSearch) currentUrl.search = '';
+            if (excludeHash) currentUrl.hash = '';
+            currentUrl = currentUrl.toString();
+
+            if (currentUrl !== currentRef) {
+                setTimeout(track, delayDuration);
+            }
+        };
+
+        const handlePathChanges = () => {
+            const hook = (_this, method, callback) => {
+                const orig = _this[method];
+                return (...args) => {
+                    callback.apply(null, args);
+                    return orig.apply(_this, args);
+                };
+            };
+
+            history.pushState = hook(history, 'pushState', handlePush);
+            history.replaceState = hook(history, 'replaceState', handlePush);
+        };
+
+        const handleClicks = () => {
+            const trackElement = async el => {
+                const eventName = el.getAttribute(eventNameAttribute);
+                if (eventName) {
+                    const eventData = {};
+
+                    el.getAttributeNames().forEach(name => {
+                        const match = name.match(eventRegex);
+                        if (match) eventData[match[1]] = el.getAttribute(name);
+                    });
+
+                    return track(eventName, eventData);
+                }
+            };
+            const onClick = async e => {
+                const el = e.target;
+                const parentElement = el.closest('a,button');
+                if (!parentElement) return trackElement(el);
+
+                const { href, target } = parentElement;
+                if (!parentElement.getAttribute(eventNameAttribute)) return;
+
+                if (parentElement.tagName === 'BUTTON') {
+                    return trackElement(parentElement);
+                }
+                if (parentElement.tagName === 'A' && href) {
+                    const external =
+                        target === '_blank' ||
+                        e.ctrlKey ||
+                        e.shiftKey ||
+                        e.metaKey ||
+                        (e.button && e.button === 1);
+                    if (!external) e.preventDefault();
+                    return trackElement(parentElement).then(() => {
+                        if (!external) {
+                            (target === '_top' ? top.location : location).href = href;
+                        }
+                    });
+                }
+            };
+            document.addEventListener('click', onClick, true);
+        };
+
+        /* Tracking functions */
+
+        const trackingDisabled = () =>
+            disabled ||
+            !website ||
+            (localStorage && localStorage.getItem('umami.disabled')) ||
+            (domain && !domains.includes(hostname)) ||
+            (dnt && hasDoNotTrack());
+
+        const send = async (payload, type = 'event') => {
+            if (trackingDisabled()) return;
+
+            const callback = window[beforeSend];
+
+            if (typeof callback === 'function') {
+                payload = callback(type, payload);
+            }
+
+            console.groupCollapsed("Umami Debug");
+            console.log(payload);
+            console.groupEnd();
+
+            if (!payload) return;
+
+            try {
+                const res = await fetch(endpoint, {
+                    method: 'POST',
+                    body: JSON.stringify({ type, payload }),
+                    headers: {
+                        'Content-Type': 'application/json',
+                        ...(typeof cache !== 'undefined' && { 'x-umami-cache': cache }),
+                    },
+                    credentials: 'omit',
+                });
+
+                const data = await res.json();
+                if (data) {
+                    disabled = !!data.disabled;
+                    cache = data.cache;
+                }
+            } catch (e) {
+                /* no-op */
+            }
+        };
+
+        const init = () => {
+            if (!initialized) {
+                initialized = true;
+                track();
+                handlePathChanges();
+                handleClicks();
+            }
+        };
+
+        const track = (name, data) => {
+            if (typeof name === 'string') return send({ ...getPayload(), name, data });
+            if (typeof name === 'object') return send({ ...name });
+            if (typeof name === 'function') return send(name(getPayload()));
+            return send(getPayload());
+        };
+
+        const identify = (id, data) => {
+            if (typeof id === 'string') {
+                identity = id;
+            }
+
+            cache = '';
+            return send(
+                {
+                    ...getPayload(),
+                    data: typeof id === 'object' ? id : data,
+                },
+                'identify',
+            );
+        };
+
+        /* Start */
+
+        if (!window.umami) {
+            window.umami = {
+                track,
+                identify,
+            };
+        }
+
+        let currentUrl = href;
+        let currentRef = referrer.startsWith(origin) ? '' : referrer;
+        let initialized = false;
+        let disabled = false;
+        let cache;
+        let identity;
+
+        if (autoTrack && !trackingDisabled()) {
+            if (document.readyState === 'complete') {
+                init();
+            } else {
+                document.addEventListener('readystatechange', init, true);
+            }
+        }
+    })(window);
+
+})();

--- a/powerup/.env
+++ b/powerup/.env
@@ -1,6 +1,7 @@
 HOSTNAME="https://leaner-coffee.tatablack.net"
 
 SENTRY_LOADER="${SENTRY_LOADER}"
+UMAMI_LOADER="https://cloud.umami.is/script.js"
 
 # 5 * 60 * 1000 seconds, i.e. 5 minutes
 DEFAULT_DURATION=300000

--- a/powerup/.env
+++ b/powerup/.env
@@ -2,7 +2,7 @@ HOSTNAME="https://leaner-coffee.tatablack.net"
 
 SENTRY_LOADER="${SENTRY_LOADER}"
 
-# 5 * 60 * 1000 seconds
+# 5 * 60 * 1000 seconds, i.e. 5 minutes
 DEFAULT_DURATION=300000
 
 SUPPORTED_LOCALES=["en", "it"]

--- a/powerup/.env.development.example
+++ b/powerup/.env.development.example
@@ -3,6 +3,7 @@ HOSTNAME=
 PORT=8080
 
 SENTRY_LOADER="${SENTRY_LOADER}"
+UMAMI_LOADER="/assets/umami-2.18.0-debug.js"
 
 # 0.5 * 60 * 1000 seconds, i.e. 30 seconds
 DEFAULT_DURATION=30000

--- a/powerup/.env.development.example
+++ b/powerup/.env.development.example
@@ -1,11 +1,15 @@
+# protocol://hostname
 HOSTNAME=
 PORT=8080
 
 SENTRY_LOADER="${SENTRY_LOADER}"
 
-# 5 * 60 * 1000 seconds
-DEFAULT_DURATION=300000
+# 0.5 * 60 * 1000 seconds, i.e. 30 seconds
+DEFAULT_DURATION=30000
 
 SUPPORTED_LOCALES=["en", "it"]
 
 VERSION=$(git describe --always)-$(git branch --show-current)
+
+# Set to true if you need to approve/reapprove a self-signed certificate
+OPEN_ON_START=false

--- a/powerup/_discussion-ui.html
+++ b/powerup/_discussion-ui.html
@@ -82,7 +82,17 @@
             color: #fff;
         }
     </style>
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="1502b785-3f33-469d-8d36-174179c5a01f" data-tag="<%= ENVIRONMENT %>"></script>
+    <script
+        src="<%= UMAMI_LOADER %>"
+        data-host-url="https://cloud.umami.is"
+        data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
+        data-tag="<%= ANALYTICS_TAG %>"
+        data-auto-track="false"
+        data-exclude-search="true"
+        data-exclude-hash="true"
+        data-before-send="LeanerCoffeeAnalyticsBeforeSend"
+    >
+    </script>
 </head>
 
 <body>
@@ -109,5 +119,14 @@
     </script>
     <script src="<%= SENTRY_LOADER %>" crossorigin="anonymous"></script>
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        window.LeanerCoffeeAnalyticsReferrer = params.get("referrer");
+        window.LeanerCoffeeAnalyticsHostname = params.get("hostname");
+
+        const sanitiseUrl = eval(<%= ANALYTICS_SANITISE_URL %>);
+        window.LeanerCoffeeAnalyticsBeforeSend = eval(<%= ANALYTICS_BEFORE_SEND %>);
+        window.umami && window.umami.track();
+    </script>
 </body>
 </html>

--- a/powerup/_index.html
+++ b/powerup/_index.html
@@ -3,11 +3,17 @@
   <head>
     <meta charset="utf-8">
     <title><%= htmlWebpackPlugin.options.title %></title>
+
     <script
         defer
-        src="https://cloud.umami.is/script.js"
+        src="<%= UMAMI_LOADER %>"
+        data-host-url="https://cloud.umami.is"
         data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
-        data-tag="<%= ENVIRONMENT %>"
+        data-tag="<%= ANALYTICS_TAG %>"
+        data-auto-track="false"
+        data-exclude-search="true"
+        data-exclude-hash="true"
+        data-before-send="LeanerCoffeeAnalyticsBeforeSend"
     >
     </script>
   </head>

--- a/powerup/_ongoing_or_paused.html
+++ b/powerup/_ongoing_or_paused.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 
 <head>
-    <title data-i18n-id=""></title>
+    <title>Ongoing or paused</title>
     <meta charset="utf-8">
     <link rel="stylesheet" href="https://p.trellocdn.com/power-up.min.css" type="text/css" />
 
@@ -22,7 +22,17 @@
             background-color: rgba(9,30,66,.04);
         }
     </style>
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="1502b785-3f33-469d-8d36-174179c5a01f" data-tag="<%= ENVIRONMENT %>"></script>
+    <script
+        src="<%= UMAMI_LOADER %>"
+        data-host-url="https://cloud.umami.is"
+        data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
+        data-tag="<%= ANALYTICS_TAG %>"
+        data-auto-track="false"
+        data-exclude-search="true"
+        data-exclude-hash="true"
+        data-before-send="LeanerCoffeeAnalyticsBeforeSend"
+    >
+    </script>
 </head>
 
 <body>
@@ -40,6 +50,15 @@
     </script>
     <script src="<%= SENTRY_LOADER %>" crossorigin="anonymous"></script>
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        window.LeanerCoffeeAnalyticsReferrer = params.get("referrer");
+        window.LeanerCoffeeAnalyticsHostname = params.get("hostname");
+
+        const sanitiseUrl = eval(<%= ANALYTICS_SANITISE_URL %>);
+        window.LeanerCoffeeAnalyticsBeforeSend = eval(<%= ANALYTICS_BEFORE_SEND %>);
+        window.umami && window.umami.track();
+    </script>
 </body>
 
 </html>

--- a/powerup/_settings.html
+++ b/powerup/_settings.html
@@ -17,7 +17,17 @@
             margin-bottom: 0.2em;
         }
     </style>
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="1502b785-3f33-469d-8d36-174179c5a01f" data-tag="<%= ENVIRONMENT %>"></script>
+    <script
+        src="<%= UMAMI_LOADER %>"
+        data-host-url="https://cloud.umami.is"
+        data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
+        data-tag="<%= ANALYTICS_TAG %>"
+        data-auto-track="false"
+        data-exclude-search="true"
+        data-exclude-hash="true"
+        data-before-send="LeanerCoffeeAnalyticsBeforeSend"
+    >
+    </script>
 </head>
 
 <body>
@@ -39,12 +49,12 @@
             <h3 data-i18n-id="settingsDebugSection"></h3>
             <div>
                 <button
-                        id="showData"
-                        data-i18n-id="settingsDebugShowData"></button>
+                    id="showData"
+                    data-i18n-id="settingsDebugShowData"></button>
                 <button
-                        id="wipeData"
-                        data-i18n-id="settingsDebugWipeData"
-                        class="mod-danger"></button>
+                    id="wipeData"
+                    data-i18n-id="settingsDebugWipeData"
+                    class="mod-danger"></button>
             </div>
         </section>
     </form>
@@ -56,5 +66,14 @@
     </script>
     <script src="<%= SENTRY_LOADER %>" crossorigin="anonymous"></script>
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        window.LeanerCoffeeAnalyticsReferrer = params.get("referrer");
+        window.LeanerCoffeeAnalyticsHostname = params.get("hostname");
+
+        const sanitiseUrl = eval(<%= ANALYTICS_SANITISE_URL %>);
+        window.LeanerCoffeeAnalyticsBeforeSend = eval(<%= ANALYTICS_BEFORE_SEND %>);
+        window.umami && window.umami.track();
+    </script>
 </body>
 </html>

--- a/powerup/release-notes.html
+++ b/powerup/release-notes.html
@@ -30,19 +30,15 @@
             }
         </style>
         <script
-                defer
-                src="https://cloud.umami.is/script.js"
-                data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
-                data-tag="ENVIRONMENT">
-        </script>
-        <script>
-            const Analytics = {
-                async event(window, eventName, eventData) {
-                    if (window.umami) {
-                        await window.umami.track(eventName, eventData);
-                    }
-                },
-            };
+            src="UMAMI_LOADER"
+            data-host-url="https://cloud.umami.is"
+            data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
+            data-tag="ANALYTICS_TAG"
+            data-auto-track="false"
+            data-exclude-search="true"
+            data-exclude-hash="true"
+            data-before-send="LeanerCoffeeAnalyticsBeforeSend"
+        >
         </script>
     </head>
 
@@ -88,6 +84,14 @@
               t.localizeNode(document.body);
               t.sizeTo('body');
             });
+
+            const params = new URLSearchParams(window.location.search);
+            window.LeanerCoffeeAnalyticsReferrer = params.get("referrer");
+            window.LeanerCoffeeAnalyticsHostname = params.get("hostname");
+
+            const sanitiseUrl = eval(ANALYTICS_SANITISE_URL);
+            window.LeanerCoffeeAnalyticsBeforeSend = eval(ANALYTICS_BEFORE_SEND);
+            window.umami && window.umami.track();
         </script>
     </body>
 </html>

--- a/powerup/src/CapabilityHandlers.ts
+++ b/powerup/src/CapabilityHandlers.ts
@@ -1,10 +1,11 @@
+import LeanCoffeePowerUp from "./LeanCoffeePowerUp";
 import CardStorage from "./storage/CardStorage";
 import { Trello } from "./types/TrelloPowerUp";
 import Analytics from "./utils/Analytics";
 import { I18nConfig } from "./utils/I18nConfig";
 
 export const CapabilityHandlers = (
-  powerUp: any,
+  powerUp: LeanCoffeePowerUp,
 ): Trello.PowerUp.CapabilityHandlers => ({
   "board-buttons": async (
     t: Trello.PowerUp.IFrame,
@@ -39,7 +40,9 @@ export const CapabilityHandlers = (
       icon: `${powerUp.baseUrl}/assets/powerup/timer.svg`,
       content: {
         type: "iframe",
-        url: t.signUrl(`${powerUp.baseUrl}/discussion-ui.html`),
+        url: t.signUrl(
+          `${powerUp.baseUrl}/discussion-ui.html?${await Analytics.getOverrides(powerUp.boardStorage, t)}`,
+        ),
       },
     };
   },
@@ -175,13 +178,14 @@ export const CapabilityHandlers = (
     await Analytics.event(window, "disabled");
   },
 
-  "show-settings": (t: Trello.PowerUp.IFrame): PromiseLike<void> =>
-    t.popup({
+  "show-settings": async (t: Trello.PowerUp.IFrame): Promise<void> => {
+    return t.popup({
       title: `Leaner Coffee ${process.env.VERSION}`,
-      url: `${powerUp.baseUrl}/settings.html`,
+      url: `${powerUp.baseUrl}/settings.html?${await Analytics.getOverrides(powerUp.boardStorage, t)}`,
       height: 184,
       args: {
         localization: I18nConfig,
       },
-    }),
+    });
+  },
 });

--- a/powerup/src/CapabilityHandlers.ts
+++ b/powerup/src/CapabilityHandlers.ts
@@ -146,8 +146,18 @@ export const CapabilityHandlers = (
     ]),
 
   "on-enable": async (t: Trello.PowerUp.IFrame): Promise<void> => {
-    await Analytics.event((t as any).source?.window[0], "enabled");
-    await powerUp.boardStorage.setPowerUpVersion(t, process.env.VERSION);
+    if (
+      powerUp.initialising ||
+      (await powerUp.boardStorage.getInitialised(t))
+    ) {
+      return;
+    }
+
+    // If we are here, on-enable was called before the power-up was initialised.
+    // I've never seen it happen, but I suppose it is possible
+    powerUp.initialising = true;
+    await powerUp.handlePowerupEnabled(t);
+    powerUp.initialising = false;
   },
 
   "on-disable": async (t: Trello.PowerUp.IFrame): Promise<void> => {

--- a/powerup/src/badges/ElapsedCardBadge.ts
+++ b/powerup/src/badges/ElapsedCardBadge.ts
@@ -28,12 +28,9 @@ class ElapsedCardBadge implements ElapsedCardBadge {
     return (await this.discussion.isPausedFor(t)) ? "yellow" : "light-gray";
   };
 
-  // Unable to use class properties here because I need to call
-  // it from a subclass, and it's currently broken - see:
-  // https://github.com/babel/babel/issues/5104
-  //
-  // Upgrading to Babel 7.x should solve it.
-  // NOTE: CHECK whether this is still relevant for ts-loader
+  // Unable to use class properties here because in subclasses
+  // I need to user `super`, and it wouldn't be possible. See:
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/super#accessing_super_in_class_field_declaration
   async render(t: Trello.PowerUp.IFrame): Promise<Trello.PowerUp.CardBadge> {
     const elapsed = await this.discussion.getElapsed(t);
     if (!elapsed) {

--- a/powerup/src/badges/VotingCardBadge.ts
+++ b/powerup/src/badges/VotingCardBadge.ts
@@ -1,3 +1,4 @@
+import BoardStorage from "../storage/BoardStorage";
 import CardStorage from "../storage/CardStorage";
 import { Trello } from "../types/TrelloPowerUp";
 import Voting from "../utils/Voting";
@@ -6,18 +7,21 @@ class VotingCardBadge {
   w: Window;
   baseUrl: string;
   voting: Voting;
-  storage: CardStorage;
+  boardStorage: BoardStorage;
+  cardStorage: CardStorage;
 
   constructor(
     w: Window,
     baseUrl: string,
     voting: Voting,
-    storage: CardStorage,
+    boardStorage: BoardStorage,
+    cardStorage: CardStorage,
   ) {
     this.w = w;
     this.baseUrl = baseUrl;
     this.voting = voting;
-    this.storage = storage;
+    this.boardStorage = boardStorage;
+    this.cardStorage = cardStorage;
     this.render = this.render.bind(this);
   }
 

--- a/powerup/src/badges/VotingCardDetailBadge.ts
+++ b/powerup/src/badges/VotingCardDetailBadge.ts
@@ -7,7 +7,7 @@ class VotingCardDetailBadge extends VotingCardBadge {
   clearVoters = async (t: Trello.PowerUp.IFrame) => {
     const totalVoters = await this.getVoters(t);
 
-    await this.storage.deleteVotes(t);
+    await this.cardStorage.deleteVotes(t);
     await Analytics.event(this.w, "votesCleared", {
       total: totalVoters.length,
     });
@@ -22,8 +22,11 @@ class VotingCardDetailBadge extends VotingCardBadge {
 
     await t.popup({
       title: t.localizeKey("voters"),
-      url: "./voters.html",
-      args: { items, localization: I18nConfig },
+      url: `./voters.html?${await Analytics.getOverrides(this.boardStorage, t)}`,
+      args: {
+        items,
+        localization: I18nConfig,
+      },
       callback: this.clearVoters,
     });
   };

--- a/powerup/src/storage/BoardStorage.ts
+++ b/powerup/src/storage/BoardStorage.ts
@@ -8,48 +8,108 @@ class BoardStorage extends Storage {
   static DISCUSSION_PREVIOUS_ELAPSED = "leancoffeeDiscussionPreviousElapsed";
   static DISCUSSION_INTERVAL_ID = "leancoffeeDiscussionIntervalId";
   static POWER_UP_VERSION = "powerUpVersion";
+  static POWER_UP_INSTALLATION_DATE = "powerUpInstallationDate";
+  static ORGANISATION_HASH = "organisationHash";
+  static BOARD_HASH = "boardHash";
 
   constructor() {
     super("board", "shared");
   }
 
   async getDiscussionStatus(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
   ): Promise<DiscussionStatus> {
     return super.read(t, BoardStorage.DISCUSSION_STATUS);
   }
 
-  async getDiscussionCardId(t: Trello.PowerUp.IFrame): Promise<string> {
+  async getDiscussionCardId(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+  ): Promise<string> {
     return super.read(t, BoardStorage.DISCUSSION_CARD_ID);
   }
 
   async getDiscussionStartedAt(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
   ): Promise<DiscussionStartedAt> {
     return super.read(t, BoardStorage.DISCUSSION_STARTED_AT);
   }
 
   async getDiscussionPreviousElapsed(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
   ): Promise<DiscussionPreviousElapsed> {
     return super.read(t, BoardStorage.DISCUSSION_PREVIOUS_ELAPSED);
   }
 
   async getDiscussionIntervalId(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
   ): Promise<DiscussionIntervalId> {
     return super.read(t, BoardStorage.DISCUSSION_INTERVAL_ID);
   }
 
-  async getPowerUpVersion(t: Trello.PowerUp.IFrame): Promise<string> {
+  async getPowerUpVersion(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+  ): Promise<string> {
     return super.read(t, BoardStorage.POWER_UP_VERSION);
   }
 
   setPowerUpVersion(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
     version: string,
   ): PromiseLike<void> {
     return super.write(t, BoardStorage.POWER_UP_VERSION, version);
+  }
+
+  async getPowerUpInstallationDate(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+  ): Promise<string> {
+    return super.read(t, BoardStorage.POWER_UP_INSTALLATION_DATE);
+  }
+
+  setPowerUpInstallationDate(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+    installationDate: string,
+  ): PromiseLike<void> {
+    return super.write(
+      t,
+      BoardStorage.POWER_UP_INSTALLATION_DATE,
+      installationDate,
+    );
+  }
+
+  async getOrganisationIdHash(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+  ): Promise<string> {
+    return super.read(t, BoardStorage.ORGANISATION_HASH);
+  }
+
+  async setOrganisationIdHash(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+    value: string,
+  ): Promise<void> {
+    return super.write(t, BoardStorage.ORGANISATION_HASH, value);
+  }
+
+  async getBoardIdHash(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+  ): Promise<string> {
+    return super.read(t, BoardStorage.BOARD_HASH);
+  }
+
+  async setBoardIdHash(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+    value: string,
+  ): Promise<void> {
+    return super.write(t, BoardStorage.BOARD_HASH, value);
+  }
+
+  async getInitialised(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+  ): Promise<boolean> {
+    const installationDate = await super.read(
+      t,
+      BoardStorage.POWER_UP_INSTALLATION_DATE,
+    );
+    return !!installationDate;
   }
 }
 

--- a/powerup/src/storage/CardStorage.ts
+++ b/powerup/src/storage/CardStorage.ts
@@ -12,24 +12,32 @@ class CardStorage extends Storage {
     super("card", "shared");
   }
 
-  getDiscussionStatus(t: Trello.PowerUp.IFrame): PromiseLike<DiscussionStatus> {
+  getDiscussionStatus(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+  ): PromiseLike<DiscussionStatus> {
     return super.read(t, CardStorage.DISCUSSION_STATUS);
   }
 
-  getDiscussionElapsed(t: Trello.PowerUp.IFrame): PromiseLike<number> {
+  getDiscussionElapsed(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+  ): PromiseLike<number> {
     return super.read(t, CardStorage.DISCUSSION_ELAPSED);
   }
 
-  getDiscussionThumbs(t: Trello.PowerUp.IFrame): PromiseLike<Thumbs> {
+  getDiscussionThumbs(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+  ): PromiseLike<Thumbs> {
     return super.read(t, CardStorage.DISCUSSION_THUMBS);
   }
 
-  getDiscussionButtonLabel(t: Trello.PowerUp.IFrame): PromiseLike<string> {
+  getDiscussionButtonLabel(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+  ): PromiseLike<string> {
     return super.read(t, CardStorage.DISCUSSION_BUTTON_LABEL);
   }
 
   saveDiscussionStatus(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
     newStatus: DiscussionStatus,
     cardId?: string,
   ): PromiseLike<void> {
@@ -37,7 +45,7 @@ class CardStorage extends Storage {
   }
 
   saveDiscussionElapsed(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
     newElapsed: number,
     cardId?: string,
   ): PromiseLike<void> {
@@ -45,28 +53,33 @@ class CardStorage extends Storage {
   }
 
   saveDiscussionThumbs(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
     newThumbs: Thumbs,
   ): PromiseLike<void> {
     return super.write(t, CardStorage.DISCUSSION_THUMBS, newThumbs);
   }
 
-  saveVotes(t: Trello.PowerUp.IFrame, newVotes: Votes): PromiseLike<void> {
+  saveVotes(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+    newVotes: Votes,
+  ): PromiseLike<void> {
     return super.write(t, CardStorage.VOTES, newVotes);
   }
 
-  deleteVotes(t: Trello.PowerUp.IFrame): PromiseLike<void> {
+  deleteVotes(t: Trello.PowerUp.AnonymousHostHandlers): PromiseLike<void> {
     return super.delete(t, CardStorage.VOTES);
   }
 
   saveDiscussionButtonLabel(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
     newLabel?: string,
   ): PromiseLike<void> {
     return super.write(t, CardStorage.DISCUSSION_BUTTON_LABEL, newLabel);
   }
 
-  deleteDiscussionThumbs(t: Trello.PowerUp.IFrame): PromiseLike<void> {
+  deleteDiscussionThumbs(
+    t: Trello.PowerUp.AnonymousHostHandlers,
+  ): PromiseLike<void> {
     return super.delete(t, CardStorage.DISCUSSION_THUMBS);
   }
 }

--- a/powerup/src/storage/Storage.ts
+++ b/powerup/src/storage/Storage.ts
@@ -12,7 +12,7 @@ class Storage {
   }
 
   read(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
     key: string,
     cardId?: string,
   ): PromiseLike<any> {
@@ -20,7 +20,7 @@ class Storage {
   }
 
   write(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
     key: string,
     value: any,
     cardId?: string,
@@ -29,7 +29,7 @@ class Storage {
   }
 
   writeMultiple(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
     entries: {
       [key: string]: any;
     },
@@ -39,7 +39,7 @@ class Storage {
   }
 
   delete(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
     key: string,
     cardId?: string,
   ): PromiseLike<void> {
@@ -47,7 +47,7 @@ class Storage {
   }
 
   deleteMultiple(
-    t: Trello.PowerUp.IFrame,
+    t: Trello.PowerUp.AnonymousHostHandlers,
     entries: string[],
     cardId?: string,
   ): PromiseLike<void> {

--- a/powerup/src/types/TrelloPowerUp/index.d.ts
+++ b/powerup/src/types/TrelloPowerUp/index.d.ts
@@ -660,5 +660,11 @@ declare global {
     TrelloPowerUp: Trello.PowerUp;
     locale: string;
     umami: umami.umami;
+    LeanerCoffeeAnalyticsBeforeSend: (
+      event: string,
+      payload: umami.CustomPayload,
+    ) => umami.CustomPayload;
+    LeanerCoffeeAnalyticsReferrer: string;
+    LeanerCoffeeAnalyticsHostname: string;
   }
 }

--- a/powerup/src/utils/Analytics.ts
+++ b/powerup/src/utils/Analytics.ts
@@ -1,13 +1,66 @@
+import CustomPayload = umami.CustomPayload;
+
+import BoardStorage from "../storage/BoardStorage";
+import { Trello } from "../types/TrelloPowerUp";
+
+const sanitiseUrl = (urlString: string): string => {
+  const url = new URL(urlString);
+  return (
+    url.protocol +
+    url.hostname +
+    (url.port ? `:${url.port}` : "") +
+    url.pathname
+  );
+};
+
+const beforeSend = (event: string, payload: CustomPayload): CustomPayload => {
+  return {
+    ...payload,
+    ...{
+      referrer: window.LeanerCoffeeAnalyticsReferrer,
+      hostname: window.LeanerCoffeeAnalyticsHostname,
+    },
+    url: sanitiseUrl(payload.url),
+  };
+};
+
+const pageview = async (window: Window, eventData: umami.EventData = {}) => {
+  if (window.umami) {
+    await window.umami.track((props: any) => {
+      return { ...props, ...eventData };
+    });
+  } else {
+    console.warn("Umami not available for pageview", eventData);
+  }
+};
+
+const event = async (
+  window: Window,
+  eventName: string,
+  eventData?: umami.EventData,
+) => {
+  if (window.umami) {
+    await window.umami.track(eventName, eventData);
+  } else {
+    console.warn("Umami not available for event", eventData);
+  }
+};
+
+const getOverrides = async (
+  boardStorage: BoardStorage,
+  t: Trello.PowerUp.AnonymousHostHandlers,
+): Promise<string> => {
+  const organisationIdHash = await boardStorage.getOrganisationIdHash(t);
+  const boardIdHash = await boardStorage.getBoardIdHash(t);
+  const referrer = encodeURIComponent("https://" + organisationIdHash);
+  return `referrer=${referrer}&hostname=${boardIdHash}`;
+};
+
 const Analytics = {
-  async event(
-    window: Window,
-    eventName: string,
-    eventData?: Record<string, unknown>,
-  ) {
-    if (window.umami) {
-      await window.umami.track(eventName, eventData);
-    }
-  },
+  beforeSend,
+  pageview,
+  event,
+  getOverrides,
 };
 
 export default Analytics;

--- a/powerup/src/utils/Hashing.ts
+++ b/powerup/src/utils/Hashing.ts
@@ -1,0 +1,10 @@
+// https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
+export async function digestMessage(message: string) {
+  const msgUint8 = new TextEncoder().encode(message); // encode as (utf-8) Uint8Array
+  const hashBuffer = await window.crypto.subtle.digest("SHA-256", msgUint8); // hash the message
+  const hashArray = Array.from(new Uint8Array(hashBuffer)); // convert buffer to byte array
+  const hashHex = hashArray
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join(""); // convert bytes to hex string
+  return hashHex;
+}

--- a/powerup/src/utils/UpdateChecker.ts
+++ b/powerup/src/utils/UpdateChecker.ts
@@ -1,3 +1,4 @@
+import Analytics from "./Analytics";
 import { I18nConfig } from "./I18nConfig";
 import BoardStorage from "../storage/BoardStorage";
 import { Trello } from "../types/TrelloPowerUp";
@@ -5,26 +6,26 @@ import { Trello } from "../types/TrelloPowerUp";
 const LAST_UNCHECKED_VERSION = "0.6.2";
 
 class UpdateChecker {
-  storage: BoardStorage;
+  boardStorage: BoardStorage;
   storedVersion: string;
 
   constructor(storage: BoardStorage) {
-    this.storage = storage;
+    this.boardStorage = storage;
   }
 
   hasBeenUpdated = async (t: Trello.PowerUp.IFrame): Promise<boolean> => {
-    this.storedVersion = await this.storage.getPowerUpVersion(t);
+    this.storedVersion = await this.boardStorage.getPowerUpVersion(t);
     return !this.storedVersion || this.storedVersion !== process.env.VERSION;
   };
 
   showMenu = async (t: Trello.PowerUp.IFrame): Promise<void> => {
-    const storedVersion = await this.storage.getPowerUpVersion(t);
+    const storedVersion = await this.boardStorage.getPowerUpVersion(t);
     return t.popup({
       title: t.localizeKey("boardButtonPopupTitle", {
         oldVersion: storedVersion || LAST_UNCHECKED_VERSION,
         newVersion: process.env.VERSION,
       }),
-      url: "./release-notes.html",
+      url: `./release-notes.html?${await Analytics.getOverrides(this.boardStorage, t)}`,
       args: { version: process.env.VERSION, localization: I18nConfig },
       callback: this.storeNewVersion,
       height: 65,
@@ -32,7 +33,7 @@ class UpdateChecker {
   };
 
   storeNewVersion = async (t: Trello.PowerUp.IFrame): Promise<void> => {
-    await this.storage.setPowerUpVersion(t, process.env.VERSION);
+    await this.boardStorage.setPowerUpVersion(t, process.env.VERSION);
   };
 }
 

--- a/powerup/too_many_votes.html
+++ b/powerup/too_many_votes.html
@@ -2,16 +2,22 @@
 <html lang="en-us">
     <head>
         <meta charset="utf-8">
+        <title>Too many votes</title>
         <link
             rel="stylesheet"
             href="https://p.trellocdn.com/power-up.min.css"
             type="text/css"
         >
         <script
-            defer
-            src="https://cloud.umami.is/script.js"
+            src="UMAMI_LOADER"
+            data-host-url="https://cloud.umami.is"
             data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
-            data-tag="ENVIRONMENT">
+            data-tag="ANALYTICS_TAG"
+            data-auto-track="false"
+            data-exclude-search="true"
+            data-exclude-hash="true"
+            data-before-send="LeanerCoffeeAnalyticsBeforeSend"
+        >
         </script>
     </head>
 
@@ -49,6 +55,14 @@
               t.localizeNode(document.body);
               t.sizeTo('body');
             });
+
+            const params = new URLSearchParams(window.location.search);
+            window.LeanerCoffeeAnalyticsReferrer = params.get("referrer");
+            window.LeanerCoffeeAnalyticsHostname = params.get("hostname");
+
+            const sanitiseUrl = eval(ANALYTICS_SANITISE_URL);
+            window.LeanerCoffeeAnalyticsBeforeSend = eval(ANALYTICS_BEFORE_SEND);
+            window.umami && window.umami.track();
         </script>
     </body>
 </html>

--- a/powerup/voters.html
+++ b/powerup/voters.html
@@ -46,10 +46,15 @@
             }
         </style>
         <script
-            defer
-            src="https://cloud.umami.is/script.js"
+            src="UMAMI_LOADER"
+            data-host-url="https://cloud.umami.is"
             data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
-            data-tag="ENVIRONMENT">
+            data-tag="ANALYTICS_TAG"
+            data-auto-track="false"
+            data-exclude-search="true"
+            data-exclude-hash="true"
+            data-before-send="LeanerCoffeeAnalyticsBeforeSend"
+        >
         </script>
     </head>
 
@@ -100,6 +105,14 @@
                 t.localizeNode(document.body);
                 t.sizeTo('body');
             });
+
+            const params = new URLSearchParams(window.location.search);
+            window.LeanerCoffeeAnalyticsReferrer = params.get("referrer");
+            window.LeanerCoffeeAnalyticsHostname = params.get("hostname");
+
+            const sanitiseUrl = eval(ANALYTICS_SANITISE_URL);
+            window.LeanerCoffeeAnalyticsBeforeSend = eval(ANALYTICS_BEFORE_SEND);
+            window.umami && window.umami.track();
         </script>
     </body>
 </html>

--- a/powerup/webpack.dev.js
+++ b/powerup/webpack.dev.js
@@ -22,7 +22,7 @@ module.exports = merge(common, {
         ),
       },
     },
-    open: true,
+    open: process.env.OPEN_ON_START !== "false",
     compress: true,
     hot: true,
     liveReload: false,


### PR DESCRIPTION
In order to better understand sequences of user actions (and hopefully to build meaningful funnels) I've decided to use a hash of the Trello organisation id and of the current Board is. Umami only allows one top-level tag, so I'm hijacking two fields that would otherwise be irrelevant for this power-up, namely `referrer` and `hostname` (irrelevant because they'd only ever have one value). In order to do this, some refactoring was needed.

Changes:
- use hashes of the Trello organisation id and the current board id to further refine analytics events
- inline pageview events in each iframe apart from the main one
- improve initialisation and cleanup (considering that `on-enable` and `on-disable` are not guaranteed to be called)
- add a local copy of the analytics client for debugging purposes during development
