### PR TITLE
Update links in the documentation, in comments and in the actual power-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ From a developer's perspective, it's also a platform which can be extended using
 Yep. This project implements a Power-Up meant to support "Lean Coffee"-style sessions based on a Trello board.
 
 ## What is "Lean Coffee", then?
-From the [official page](http://leancoffee.org/):
+From the [official page](https://leancoffee.org/):
 
     Lean Coffee is a structured, but agenda-less meeting.
 
@@ -114,7 +114,7 @@ We use [SemVer](http://semver.org/) for versioning.
 Angelo Tata @tatablack
 
 ## Disclaimer
-Lean Coffee(tm) is a trademark of Modus Cooperandi (as mentioned [here](http://leancoffee.org/)); we are not affiliated with them, or with the original creators of the technique, in any way. We just happened to run plenty of Lean Coffee sessions on Trello, and we wanted to make our own lives easier. Once this proved useful, well, sharing was the next step.
+Lean Coffee(tm) is a trademark of Modus Cooperandi (as mentioned [here](https://leancoffee.org/)); we are not affiliated with them, or with the original creators of the technique, in any way. We just happened to run plenty of Lean Coffee sessions on Trello, and we wanted to make our own lives easier. Once this proved useful, well, sharing was the next step.
 
 ## License
 Apache-2.0. See [LICENSE](./LICENSE).

--- a/powerup/i18n/listings/DESCRIPTION.en.md
+++ b/powerup/i18n/listings/DESCRIPTION.en.md
@@ -1,6 +1,6 @@
 **What is Lean Coffee?**
 
-From the [official page](http://leancoffee.org/):
+From the [official page](https://leancoffee.org/):
 
     Lean Coffee is a structured, but agenda-less meeting.
 
@@ -91,7 +91,7 @@ If you have a question which you'd rather not ask publicly using [GitHub Issues]
 
 **Disclaimer**
 
-Lean Coffee(tm) is a trademark of Modus Cooperandi (as mentioned [here](http://leancoffee.org/)); we are not affiliated with them, or with the original creators of the technique, in any way. We just happened to run plenty of Lean Coffee sessions on Trello, and we wanted to make our own lives easier. Once this proved useful, well, sharing was the next step.
+Lean Coffee(tm) is a trademark of Modus Cooperandi (as mentioned [here](https://leancoffee.org/)); we are not affiliated with them, or with the original creators of the technique, in any way. We just happened to run plenty of Lean Coffee sessions on Trello, and we wanted to make our own lives easier. Once this proved useful, well, sharing was the next step.
 
 ---
 

--- a/powerup/i18n/listings/DESCRIPTION.it.md
+++ b/powerup/i18n/listings/DESCRIPTION.it.md
@@ -1,6 +1,6 @@
 **Cos'è la tecnica del Lean Coffee?**
 
-Dal [sito ufficiale](http://leancoffee.org/) (trad. nostra):
+Dal [sito ufficiale](https://leancoffee.org/) (trad. nostra):
 
     Lean Coffee è un tipo di meeting strutturato, ma senza un'agenda predefinita.
 
@@ -91,7 +91,7 @@ Se avete una domanda che preferireste non porre pubblicamente tramite [GitHub Is
 
 **Disclaimer**
 
-Lean Coffee(tm) è un marchio registrato da Modus Cooperandi (come riportato [qui](http://leancoffee.org/)); non abbiamo alcun legame con loro, nè con gli ideatori di questa tecnica. Semplicemente, ci siamo trovati di frequente in sessioni in stile Lean Coffee che usavano Trello, e volevamo semplificarci la vita. Una volta dimostrata l'utilità del power-up, beh, condividerlo era l'ovvio passo successivo.
+Lean Coffee(tm) è un marchio registrato da Modus Cooperandi (come riportato [qui](https://leancoffee.org/)); non abbiamo alcun legame con loro, nè con gli ideatori di questa tecnica. Semplicemente, ci siamo trovati di frequente in sessioni in stile Lean Coffee che usavano Trello, e volevamo semplificarci la vita. Una volta dimostrata l'utilità del power-up, beh, condividerlo era l'ovvio passo successivo.
 
 ---
 

--- a/powerup/src/utils/Voting.ts
+++ b/powerup/src/utils/Voting.ts
@@ -39,7 +39,7 @@ class Voting {
   getMaxVotes = async (t: Trello.PowerUp.IFrame): Promise<number> => {
     const currentList = await t.list("cards");
 
-    // http://www.leanmath.com/blog-entry/multi-voting-math-or-n3
+    // https://www.talcottridge.com/multi-voting-math-or-n3
     return Math.ceil(currentList.cards.length / 3);
   };
 

--- a/powerup/too_many_votes.html
+++ b/powerup/too_many_votes.html
@@ -29,8 +29,8 @@
             <a
                 target="_blank"
                 data-umami-event="outbound-link-click"
-                data-umami-event-url="http://www.leanmath.com/blog-entry/multi-voting-math-or-n3"
-                href="http://www.leanmath.com/blog-entry/multi-voting-math-or-n3"
+                data-umami-event-url="https://www.talcottridge.com/multi-voting-math-or-n3"
+                href="https://www.talcottridge.com/multi-voting-math-or-n3"
             ><span data-i18n-id="maxVotesLink"></span></a>.
         </div>
 


### PR DESCRIPTION
This power-up is "old", for Internet standards. When I first built it, it was still common to find websites that were accessible only via `http`, not `https`. One such was the Lean Coffee one.

This PR welcomes such websites into the `https` era, and also updates one stale link.