### PR TITLE
Tweak build time variables

### DIFF
--- a/powerup/.env
+++ b/powerup/.env
@@ -8,4 +8,5 @@ DEFAULT_DURATION=300000
 
 SUPPORTED_LOCALES=["en", "it"]
 
-VERSION=$(git describe --always)
+# In production, this will come from package.json
+# VERSION=

--- a/powerup/inline/sentry_init.eta
+++ b/powerup/inline/sentry_init.eta
@@ -4,8 +4,8 @@
         // https://github.com/getsentry/relay/blob/3df33b87bbbf71d65a74e285e3a43853da5ea1d9/relay-event-schema/src/protocol/event.rs#L321-L327
         Sentry.init({
         sendDefaultPii: false,
-        release: process.env.VERSION.replaceAll(/[^a-zA-Z0-9_.-]/g, "-"),
-        environment: process.env.NODE_ENV,
+        release: "<%= it.BUILDTIME_VERSION %>".replaceAll(/[^a-zA-Z0-9_.-]/g, "-"),
+        environment: "<%= it.ENVIRONMENT %>",
       });
     };
 </script>

--- a/powerup/package.json
+++ b/powerup/package.json
@@ -7,7 +7,8 @@
     "start": "NODE_ENV=development webpack serve --config ./webpack.dev.js",
     "lint": "eslint .",
     "dist": "NODE_ENV=production webpack --config webpack.prod.js",
-    "version": "npm run dist && git add -A ../docs"
+    "preversion": "pnpm run lint",
+    "version": "pnpm run dist && git add -A ../docs"
   },
   "engines": {
     "node": "^20.11.0"

--- a/powerup/src/CapabilityHandlers.ts
+++ b/powerup/src/CapabilityHandlers.ts
@@ -180,7 +180,7 @@ export const CapabilityHandlers = (
 
   "show-settings": async (t: Trello.PowerUp.IFrame): Promise<void> => {
     return t.popup({
-      title: `Leaner Coffee ${process.env.VERSION}`,
+      title: `Leaner Coffee ${__BUILDTIME_VERSION__}`,
       url: `${powerUp.baseUrl}/settings.html?${await Analytics.getOverrides(powerUp.boardStorage, t)}`,
       height: 184,
       args: {

--- a/powerup/src/LeanCoffeePowerUp.ts
+++ b/powerup/src/LeanCoffeePowerUp.ts
@@ -287,7 +287,7 @@ class LeanCoffeePowerUp extends LeanCoffeeBase {
     const boardIdHash = await digestMessage(board.id);
 
     await this.boardStorage.writeMultiple(t, {
-      [BoardStorage.POWER_UP_VERSION]: process.env.VERSION,
+      [BoardStorage.POWER_UP_VERSION]: __BUILDTIME_VERSION__,
       [BoardStorage.POWER_UP_INSTALLATION_DATE]: new Date().toISOString(),
       [BoardStorage.ORGANISATION_HASH]: organisationIdHash,
       [BoardStorage.BOARD_HASH]: boardIdHash,

--- a/powerup/src/types/TrelloPowerUp/buildtime.d.ts
+++ b/powerup/src/types/TrelloPowerUp/buildtime.d.ts
@@ -1,0 +1,1 @@
+declare const __BUILDTIME_VERSION__: string;

--- a/powerup/src/utils/Analytics.ts
+++ b/powerup/src/utils/Analytics.ts
@@ -42,7 +42,7 @@ const event = async (
   if (window.umami) {
     await window.umami.track(eventName, eventData);
   } else {
-    console.warn("Umami not available for event", eventData);
+    console.warn("Umami not available for event " + eventName, eventData);
   }
 };
 

--- a/powerup/src/utils/UpdateChecker.ts
+++ b/powerup/src/utils/UpdateChecker.ts
@@ -15,7 +15,7 @@ class UpdateChecker {
 
   hasBeenUpdated = async (t: Trello.PowerUp.IFrame): Promise<boolean> => {
     this.storedVersion = await this.boardStorage.getPowerUpVersion(t);
-    return !this.storedVersion || this.storedVersion !== process.env.VERSION;
+    return !this.storedVersion || this.storedVersion !== __BUILDTIME_VERSION__;
   };
 
   showMenu = async (t: Trello.PowerUp.IFrame): Promise<void> => {
@@ -23,17 +23,17 @@ class UpdateChecker {
     return t.popup({
       title: t.localizeKey("boardButtonPopupTitle", {
         oldVersion: storedVersion || LAST_UNCHECKED_VERSION,
-        newVersion: process.env.VERSION,
+        newVersion: __BUILDTIME_VERSION__,
       }),
       url: `./release-notes.html?${await Analytics.getOverrides(this.boardStorage, t)}`,
-      args: { version: process.env.VERSION, localization: I18nConfig },
+      args: { version: __BUILDTIME_VERSION__, localization: I18nConfig },
       callback: this.storeNewVersion,
       height: 65,
     });
   };
 
   storeNewVersion = async (t: Trello.PowerUp.IFrame): Promise<void> => {
-    await this.boardStorage.setPowerUpVersion(t, process.env.VERSION);
+    await this.boardStorage.setPowerUpVersion(t, __BUILDTIME_VERSION__);
   };
 }
 

--- a/powerup/templates/_discussion-ui.eta
+++ b/powerup/templates/_discussion-ui.eta
@@ -2,7 +2,7 @@
 <html lang="en-us">
     <head>
         <meta charset="utf-8">
-        <title><%= title %></title>
+        <title><%= it.title %></title>
 
         <link rel="stylesheet" href="https://p.trellocdn.com/power-up.min.css" type="text/css"/>
         <style>
@@ -82,10 +82,10 @@
             }
         </style>
         <script
-            src="<%= UMAMI_LOADER %>"
+            src="<%= it.UMAMI_LOADER %>"
             data-host-url="https://cloud.umami.is"
             data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
-            data-tag="<%= ANALYTICS_TAG %>"
+            data-tag="<%= it.ANALYTICS_TAG %>"
             data-auto-track="false"
             data-exclude-search="true"
             data-exclude-hash="true"
@@ -111,8 +111,8 @@
             <div class="badge voting voting-down">0</div>
         </div>
 
-        <%~ include('inline/sentry_init.eta') %>
-        <script src="<%= SENTRY_LOADER %>" crossorigin="anonymous"></script>
+        <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
+        <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script src="@scripts/discussion-ui.ts" defer="defer"></script>
         <%~ include('inline/umami_init.eta') %>

--- a/powerup/templates/_discussion-ui.eta
+++ b/powerup/templates/_discussion-ui.eta
@@ -115,6 +115,6 @@
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script src="@scripts/discussion-ui.ts" defer="defer"></script>
-        <%~ include('inline/umami_init.eta') %>
+        <%~ include('inline/umami_init') %>
     </body>
 </html>

--- a/powerup/templates/_index.eta
+++ b/powerup/templates/_index.eta
@@ -2,14 +2,14 @@
 <html lang="en-us">
   <head>
     <meta charset="utf-8">
-    <title><%= title %></title>
+    <title><%= it.title %></title>
 
     <script
         defer
-        src="<%= UMAMI_LOADER %>"
+        src="<%= it.UMAMI_LOADER %>"
         data-host-url="https://cloud.umami.is"
         data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
-        data-tag="<%= ANALYTICS_TAG %>"
+        data-tag="<%= it.ANALYTICS_TAG %>"
         data-auto-track="false"
         data-exclude-search="true"
         data-exclude-hash="true"
@@ -19,8 +19,8 @@
   </head>
 
   <body>
-    <%~ include('inline/sentry_init.eta') %>
-    <script src="<%= SENTRY_LOADER %>" crossorigin="anonymous"></script>
+    <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
+    <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
     <script src="https://p.trellocdn.com/power-up.min.js"></script>
     <script src="@scripts/index.ts" defer="defer"></script>
   </body>

--- a/powerup/templates/_ongoing_or_paused.eta
+++ b/powerup/templates/_ongoing_or_paused.eta
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-us">
     <head>
-        <title><%= title %></title>
+        <title><%= it.title %></title>
         <meta charset="utf-8">
         <link rel="stylesheet" href="https://p.trellocdn.com/power-up.min.css" type="text/css" />
 
@@ -22,10 +22,10 @@
             }
         </style>
         <script
-            src="<%= UMAMI_LOADER %>"
+            src="<%= it.UMAMI_LOADER %>"
             data-host-url="https://cloud.umami.is"
             data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
-            data-tag="<%= ANALYTICS_TAG %>"
+            data-tag="<%= it.ANALYTICS_TAG %>"
             data-auto-track="false"
             data-exclude-search="true"
             data-exclude-hash="true"
@@ -42,8 +42,8 @@
         <hr/>
         <a id="start-button" data-i18n-id="startTimer" data-i18n-args='{"symbol": "▶"}'></a>
 
-        <%~ include('inline/sentry_init.eta') %>
-        <script src="<%= SENTRY_LOADER %>" crossorigin="anonymous"></script>
+        <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
+        <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script src="@scripts/popups/ongoing_or_paused.ts" defer="defer"></script>
         <%~ include('inline/umami_init.eta') %>

--- a/powerup/templates/_ongoing_or_paused.eta
+++ b/powerup/templates/_ongoing_or_paused.eta
@@ -46,6 +46,6 @@
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script src="@scripts/popups/ongoing_or_paused.ts" defer="defer"></script>
-        <%~ include('inline/umami_init.eta') %>
+        <%~ include('inline/umami_init') %>
     </body>
 </html>

--- a/powerup/templates/_settings.eta
+++ b/powerup/templates/_settings.eta
@@ -2,7 +2,7 @@
 <html lang="en-us">
     <head>
         <meta charset="utf-8">
-        <title><%= title %></title>
+        <title><%= it.title %></title>
 
         <link rel="stylesheet" href="https://p.trellocdn.com/power-up.min.css" type="text/css" />
 
@@ -17,10 +17,10 @@
             }
         </style>
         <script
-            src="<%= UMAMI_LOADER %>"
+            src="<%= it.UMAMI_LOADER %>"
             data-host-url="https://cloud.umami.is"
             data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
-            data-tag="<%= ANALYTICS_TAG %>"
+            data-tag="<%= it.ANALYTICS_TAG %>"
             data-auto-track="false"
             data-exclude-search="true"
             data-exclude-hash="true"
@@ -58,8 +58,8 @@
             </section>
         </form>
 
-        <%~ include('inline/sentry_init.eta') %>
-        <script src="<%= SENTRY_LOADER %>" crossorigin="anonymous"></script>
+        <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
+        <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script src="@scripts/settings.ts" defer="defer"></script>
         <%~ include('inline/umami_init.eta') %>

--- a/powerup/templates/_settings.eta
+++ b/powerup/templates/_settings.eta
@@ -62,6 +62,6 @@
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script src="@scripts/settings.ts" defer="defer"></script>
-        <%~ include('inline/umami_init.eta') %>
+        <%~ include('inline/umami_init') %>
     </body>
 </html>

--- a/powerup/templates/release-notes.eta
+++ b/powerup/templates/release-notes.eta
@@ -67,7 +67,7 @@
 
             document.getElementById('open').addEventListener('click', async () => {
               const url = `https://github.com/tatablack/leaner-coffee-powerup/releases/tag/${t.arg('version')}`;
-              await Analytics.event(window, 'outbound-link-click', {url});
+              window.umami.track("outbound-link-click", {url});
               window.open(url);
               t.closePopup();
               return false;

--- a/powerup/templates/release-notes.eta
+++ b/powerup/templates/release-notes.eta
@@ -2,7 +2,7 @@
 <html lang="en-us">
     <head>
         <meta charset="utf-8">
-        <title><%= title %></title>
+        <title><%= it.title %></title>
         <link
             rel="stylesheet"
             href="https://p.trellocdn.com/power-up.min.css"
@@ -30,10 +30,10 @@
             }
         </style>
         <script
-            src="<%= UMAMI_LOADER %>"
+            src="<%= it.UMAMI_LOADER %>"
             data-host-url="https://cloud.umami.is"
             data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
-            data-tag="<%= ANALYTICS_TAG %>"
+            data-tag="<%= it.ANALYTICS_TAG %>"
             data-auto-track="false"
             data-exclude-search="true"
             data-exclude-hash="true"
@@ -53,8 +53,8 @@
             </li>
         </ul>
 
-        <%~ include('inline/sentry_init.eta') %>
-        <script src="<%= SENTRY_LOADER %>" crossorigin="anonymous"></script>
+        <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
+        <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script>
             const t = window.TrelloPowerUp.iframe();

--- a/powerup/templates/release-notes.eta
+++ b/powerup/templates/release-notes.eta
@@ -67,7 +67,7 @@
 
             document.getElementById('open').addEventListener('click', async () => {
               const url = `https://github.com/tatablack/leaner-coffee-powerup/releases/tag/${t.arg('version')}`;
-              window.umami.track("outbound-link-click", {url});
+              window.umami && window.umami.track("outbound-link-click", {url});
               window.open(url);
               t.closePopup();
               return false;

--- a/powerup/templates/release-notes.eta
+++ b/powerup/templates/release-notes.eta
@@ -81,6 +81,6 @@
               t.sizeTo('body');
             });
         </script>
-        <%~ include('inline/umami_init.eta') %>
+        <%~ include('inline/umami_init') %>
     </body>
 </html>

--- a/powerup/templates/too_many_votes.eta
+++ b/powerup/templates/too_many_votes.eta
@@ -2,17 +2,17 @@
 <html lang="en-us">
     <head>
         <meta charset="utf-8">
-        <title><%= title %></title>
+        <title><%= it.title %></title>
         <link
             rel="stylesheet"
             href="https://p.trellocdn.com/power-up.min.css"
             type="text/css"
         >
         <script
-            src="<%= UMAMI_LOADER %>"
+            src="<%= it.UMAMI_LOADER %>"
             data-host-url="https://cloud.umami.is"
             data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
-            data-tag="<%= ANALYTICS_TAG %>"
+            data-tag="<%= it.ANALYTICS_TAG %>"
             data-auto-track="false"
             data-exclude-search="true"
             data-exclude-hash="true"
@@ -34,8 +34,8 @@
             ><span data-i18n-id="maxVotesLink"></span></a>.
         </div>
 
-        <%~ include('inline/sentry_init.eta') %>
-        <script src="<%= SENTRY_LOADER %>" crossorigin="anonymous"></script>
+        <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
+        <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script>
             const t = window.TrelloPowerUp.iframe();

--- a/powerup/templates/too_many_votes.eta
+++ b/powerup/templates/too_many_votes.eta
@@ -52,7 +52,7 @@
               t.sizeTo('body');
             });
         </script>
-        <%~ include('inline/umami_init.eta') %>
+        <%~ include('inline/umami_init') %>
     </body>
 </html>
 

--- a/powerup/templates/voters.eta
+++ b/powerup/templates/voters.eta
@@ -2,7 +2,7 @@
 <html lang="en-us">
     <head>
         <meta charset="utf-8">
-        <title><%= title %></title>
+        <title><%= it.title %></title>
         <link
             rel="stylesheet"
             href="https://p.trellocdn.com/power-up.min.css"
@@ -46,10 +46,10 @@
             }
         </style>
         <script
-            src="<%= UMAMI_LOADER %>"
+            src="<%= it.UMAMI_LOADER %>"
             data-host-url="https://cloud.umami.is"
             data-website-id="1502b785-3f33-469d-8d36-174179c5a01f"
-            data-tag="<%= ANALYTICS_TAG %>"
+            data-tag="<%= it.ANALYTICS_TAG %>"
             data-auto-track="false"
             data-exclude-search="true"
             data-exclude-hash="true"
@@ -62,8 +62,8 @@
         <ul id="voters"></ul>
         <div id="clear" class="button" data-i18n-id="clearVotesFromCard"></div>
 
-        <%~ include('inline/sentry_init.eta') %>
-        <script src="<%= SENTRY_LOADER %>" crossorigin="anonymous"></script>
+        <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
+        <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script>
             const t = window.TrelloPowerUp.iframe();

--- a/powerup/templates/voters.eta
+++ b/powerup/templates/voters.eta
@@ -102,6 +102,6 @@
                 t.sizeTo('body');
             });
         </script>
-        <%~ include('inline/umami_init.eta') %>
+        <%~ include('inline/umami_init') %>
     </body>
 </html>

--- a/powerup/webpack.common.js
+++ b/powerup/webpack.common.js
@@ -69,10 +69,13 @@ module.exports = {
   },
 
   plugins: [
+    new webpack.DefinePlugin({
+      __BUILDTIME_VERSION__: isProduction
+        ? JSON.stringify(PACKAGE_JSON.version)
+        : JSON.stringify(process.env.VERSION),
+    }),
     new webpack.EnvironmentPlugin({
-      NODE_ENV: process.env.NODE_ENV,
       CONFIG: Config,
-      VERSION: process.env.VERSION,
     }),
 
     new HtmlBundlerPlugin({
@@ -135,10 +138,7 @@ module.exports = {
           from: path.resolve(__dirname, "..", "assets"),
           to: "assets",
           globOptions: {
-            ignore:
-              process.env.NODE_ENV === "production"
-                ? []
-                : ["assets/listings/**/*"],
+            ignore: isProduction ? [] : ["assets/listings/**/*"],
           },
         },
         {

--- a/powerup/webpack.common.js
+++ b/powerup/webpack.common.js
@@ -17,6 +17,9 @@ dotenvx.config({
 });
 
 const isProduction = process.env.NODE_ENV === "production";
+const BUILDTIME_VERSION = isProduction
+  ? PACKAGE_JSON.version
+  : process.env.VERSION;
 
 const Config = {
   [process.env.NODE_ENV]: {
@@ -30,11 +33,11 @@ const Config = {
 const TEMPLATE_PARAMETERS = {
   SENTRY_LOADER: process.env.SENTRY_LOADER,
   UMAMI_LOADER: process.env.UMAMI_LOADER,
-  ANALYTICS_TAG: `${process.env.NODE_ENV}_${process.env.VERSION}`.substring(
+  ANALYTICS_TAG: `${process.env.NODE_ENV}_${BUILDTIME_VERSION}`.substring(
     0,
     50,
   ),
-  BUILDTIME_VERSION: isProduction ? PACKAGE_JSON.version : process.env.VERSION,
+  BUILDTIME_VERSION,
   ENVIRONMENT: process.env.NODE_ENV,
 };
 
@@ -70,9 +73,7 @@ module.exports = {
 
   plugins: [
     new webpack.DefinePlugin({
-      __BUILDTIME_VERSION__: isProduction
-        ? JSON.stringify(PACKAGE_JSON.version)
-        : JSON.stringify(process.env.VERSION),
+      __BUILDTIME_VERSION__: JSON.stringify(BUILDTIME_VERSION),
     }),
     new webpack.EnvironmentPlugin({
       CONFIG: Config,

--- a/powerup/webpack.common.js
+++ b/powerup/webpack.common.js
@@ -6,6 +6,8 @@ const HtmlBundlerPlugin = require("html-bundler-webpack-plugin");
 const yaml = require("js-yaml");
 const webpack = require("webpack");
 
+const PACKAGE_JSON = require("./package.json");
+
 const OUTPUT_FOLDER = "../docs";
 
 // Load configuration
@@ -13,6 +15,8 @@ dotenvx.config({
   strict: true,
   path: process.env.NODE_ENV === "development" ? ".env.development" : ".env",
 });
+
+const isProduction = process.env.NODE_ENV === "production";
 
 const Config = {
   [process.env.NODE_ENV]: {
@@ -30,6 +34,8 @@ const TEMPLATE_PARAMETERS = {
     0,
     50,
   ),
+  BUILDTIME_VERSION: isProduction ? PACKAGE_JSON.version : process.env.VERSION,
+  ENVIRONMENT: process.env.NODE_ENV,
 };
 
 module.exports = {
@@ -70,48 +76,51 @@ module.exports = {
     }),
 
     new HtmlBundlerPlugin({
+      preprocessorOptions: {
+        useWith: false,
+      },
       entry: [
         {
-          data: {
-            title: "Lean Coffee Trello Power-up",
-            ...TEMPLATE_PARAMETERS,
-          },
-          import: "./templates/_index.eta",
+          data: { title: "Lean Coffee Trello Power-up" },
+          import: "templates/_index.eta",
           filename: "index.html",
         },
         {
-          data: { title: "Lean Coffee Settings", ...TEMPLATE_PARAMETERS },
-          import: "./templates/_settings.eta",
+          data: { title: "Lean Coffee Settings" },
+          import: "templates/_settings.eta",
           filename: "settings.html",
         },
         {
-          data: { title: "Discussion UI", ...TEMPLATE_PARAMETERS },
-          import: "./templates/_discussion-ui.eta",
+          data: { title: "Discussion UI" },
+          import: "templates/_discussion-ui.eta",
           filename: "discussion-ui.html",
         },
         {
-          data: { title: "Ongoing or paused", ...TEMPLATE_PARAMETERS },
-          import: "./templates/_ongoing_or_paused.eta",
+          data: { title: "Ongoing or paused" },
+          import: "templates/_ongoing_or_paused.eta",
           filename: "ongoing_or_paused.html",
         },
         {
-          data: { title: "Release notes", ...TEMPLATE_PARAMETERS },
-          import: "./templates/release-notes.eta",
+          data: { title: "Release notes" },
+          import: "templates/release-notes.eta",
           filename: "release-notes.html",
         },
         {
-          data: { title: "Too many voets", ...TEMPLATE_PARAMETERS },
-          import: "./templates/too_many_votes.eta",
+          data: { title: "Too many votes" },
+          import: "templates/too_many_votes.eta",
           filename: "too_many_votes.html",
         },
         {
-          data: { title: "Voters", ...TEMPLATE_PARAMETERS },
-          import: "./templates/voters.eta",
+          data: { title: "Voters" },
+          import: "templates/voters.eta",
           filename: "voters.html",
         },
       ],
       js: {
         filename: "[name].[fullhash].js",
+      },
+      data: {
+        ...TEMPLATE_PARAMETERS,
       },
       integrity: "auto",
       minify: "auto",


### PR DESCRIPTION
The initial rationale for tweaking the templates again was that I needed the Power-up version to be taken from `package.json` for production builds, so that the existing release process can work (it's based on `npm version`).

This brought me to revisit usages of `process.env`, which I'm still ambivalent about.

Changes:
- the version of the power-up is now taken from `package.json` for production builds
- the Sentry initialisation template now relies on template variables rather than `process.env`
- references to `process.env.VERSION` across the codebase have been replaced with a global variable provided by `Webpack.DefinePlugin`
- fixed a 🐛 in a template, where an analytics event was tracked using the custom wrapper rather than the analytics library directly