### PR TITLE
Plumbing/improve initialisation

### DIFF
--- a/assets/umami-2.18.0-debug.js
+++ b/assets/umami-2.18.0-debug.js
@@ -141,17 +141,17 @@
             (dnt && hasDoNotTrack());
 
         const send = async (payload, type = 'event') => {
-            if (trackingDisabled()) return;
-
             const callback = window[beforeSend];
 
             if (typeof callback === 'function') {
                 payload = callback(type, payload);
             }
 
-            console.groupCollapsed("Umami Debug");
+            console.groupCollapsed("Umami Debug" + (trackingDisabled() ? " (disabled)" : ""));
             console.log(payload);
             console.groupEnd();
+
+            if (trackingDisabled()) return;
 
             if (!payload) return;
 

--- a/powerup/src/CapabilityHandlers.ts
+++ b/powerup/src/CapabilityHandlers.ts
@@ -97,10 +97,7 @@ export const CapabilityHandlers = (
           result.cards.forEach(({ id }) => {
             powerUp.cardStorage.deleteMultiple(t2, [CardStorage.VOTES], id);
           });
-          await Analytics.event(
-            (t2 as any).source?.window[0],
-            "listVotesCleared",
-          );
+          await Analytics.event(window, "listVotesCleared");
         },
       },
     ]),
@@ -136,10 +133,7 @@ export const CapabilityHandlers = (
             return 0;
           });
 
-          await Analytics.event(
-            (t2 as any).source?.window[0],
-            "listVotesSorted",
-          );
+          await Analytics.event(window, "listVotesSorted");
 
           return {
             sortedIds: sortedCards.map((card) => card.id),
@@ -170,8 +164,7 @@ export const CapabilityHandlers = (
     await Analytics.event(window, "enabled");
   },
 
-  "on-disable": async (t: Trello.PowerUp.IFrame): Promise<void> => {
-    const window = (t as any).source?.window[1]; // The order is not guaranteed
+  "on-disable": async (): Promise<void> => {
     await Analytics.event(window, "disabled");
   },
 

--- a/powerup/src/CapabilityHandlers.ts
+++ b/powerup/src/CapabilityHandlers.ts
@@ -149,26 +149,23 @@ export const CapabilityHandlers = (
     ]),
 
   "on-enable": async (t: Trello.PowerUp.IFrame): Promise<void> => {
-    const window = (t as any).source?.window[1];
-
-    if (
-      powerUp.initialising ||
-      (await powerUp.boardStorage.getInitialised(t))
-    ) {
-      powerUp.intervalId = window.setInterval(async () => {
-        if (!powerUp.initialising) {
-          await Analytics.event(window, "enabled");
-          window.clearInterval(powerUp.intervalId);
+    // There can be a race condition between the power-up starting
+    // and the on-enable event being triggered.
+    await navigator.locks.request(
+      "powerup_init",
+      { ifAvailable: true },
+      async (lock) => {
+        const isInitialised = await powerUp.boardStorage.getInitialised(t);
+        // if the lock is null, it means LeanCoffeePowerup::start is taking care of initialisation
+        if (lock === null || isInitialised) {
+          return;
         }
-      }, 500);
-      return;
-    }
 
-    // If we are here, on-enable was called before the power-up was initialised.
-    // I've never seen it happen, but I suppose it is possible
-    powerUp.initialising = true;
-    await powerUp.handlePowerupEnabled(t);
-    powerUp.initialising = false;
+        if (!isInitialised) {
+          await powerUp.handlePowerupEnabled(t);
+        }
+      },
+    );
 
     await Analytics.event(window, "enabled");
   },


### PR DESCRIPTION
When I first implemented the initialisation code for the power-up I felt it was a bit clunky, but it worked.
This new implementation should be more robust.

Changes:
- use the [Web Locks API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API) to avoid a race condition when initialising the plugin after enabling it
- stop attempting to find a window reference from the current iframe, and just use `window` directly when necessary
- improve the (custom) debug version of the Umami script