### PR TITLE
Improve error handling

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@sentry/browser':
         specifier: ^9.18.0
         version: 9.18.0
+      '@sentry/webpack-plugin':
+        specifier: ^3.4.0
+        version: 3.4.0(webpack@5.99.8)
       '@types/format-duration':
         specifier: ^1.0.3
         version: 1.0.3
@@ -191,6 +194,73 @@ importers:
         version: 6.0.1
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.27.2':
+    resolution: {integrity: sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.27.1':
+    resolution: {integrity: sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.27.1':
+    resolution: {integrity: sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.27.2':
+    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.27.1':
+    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.27.1':
+    resolution: {integrity: sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.27.1':
+    resolution: {integrity: sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.27.2':
+    resolution: {integrity: sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/template@7.27.2':
+    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.27.1':
+    resolution: {integrity: sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.27.1':
+    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
+    engines: {node: '>=6.9.0'}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -491,13 +561,73 @@ packages:
     resolution: {integrity: sha512-2A32FFwrlZtdpBruvpcLEfucu6BpyqOk3F4Bo5smM/5q7u0pa7q5d9FSY5l3nwKEAFAoLGv3hcCb+8wxMm50xA==}
     engines: {node: '>=18'}
 
+  '@sentry/babel-plugin-component-annotate@3.4.0':
+    resolution: {integrity: sha512-tSzfc3aE7m0PM0Aj7HBDet5llH9AB9oc+tBQ8AvOqUSnWodLrNCuWeQszJ7mIBovD3figgCU3h0cvI6U5cDtsg==}
+    engines: {node: '>= 14'}
+
   '@sentry/browser@9.18.0':
     resolution: {integrity: sha512-0SWfp4J2+mH4lZOcHfyIwt9VoGD7yCGQE1cm0BPcLwKnrVQeXHtUXNYNy8HTHSjTGyoFDhEAYelE/tdA3OLcWQ==}
     engines: {node: '>=18'}
 
+  '@sentry/bundler-plugin-core@3.4.0':
+    resolution: {integrity: sha512-X1Q41AsQ6xcT6hB4wYmBDBukndKM/inT4IsR7pdKLi7ICpX2Qq6lisamBAEPCgEvnLpazSFguaiC0uiwMKAdqw==}
+    engines: {node: '>= 14'}
+
+  '@sentry/cli-darwin@2.42.2':
+    resolution: {integrity: sha512-GtJSuxER7Vrp1IpxdUyRZzcckzMnb4N5KTW7sbTwUiwqARRo+wxS+gczYrS8tdgtmXs5XYhzhs+t4d52ITHMIg==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.42.2':
+    resolution: {integrity: sha512-BOxzI7sgEU5Dhq3o4SblFXdE9zScpz6EXc5Zwr1UDZvzgXZGosUtKVc7d1LmkrHP8Q2o18HcDWtF3WvJRb5Zpw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd]
+
+  '@sentry/cli-linux-arm@2.42.2':
+    resolution: {integrity: sha512-7udCw+YL9lwq+9eL3WLspvnuG+k5Icg92YE7zsteTzWLwgPVzaxeZD2f8hwhsu+wmL+jNqbpCRmktPteh3i2mg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd]
+
+  '@sentry/cli-linux-i686@2.42.2':
+    resolution: {integrity: sha512-Sw/dQp5ZPvKnq3/y7wIJyxTUJYPGoTX/YeMbDs8BzDlu9to2LWV3K3r7hE7W1Lpbaw4tSquUHiQjP5QHCOS7aQ==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd]
+
+  '@sentry/cli-linux-x64@2.42.2':
+    resolution: {integrity: sha512-mU4zUspAal6TIwlNLBV5oq6yYqiENnCWSxtSQVzWs0Jyq97wtqGNG9U+QrnwjJZ+ta/hvye9fvL2X25D/RxHQw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd]
+
+  '@sentry/cli-win32-i686@2.42.2':
+    resolution: {integrity: sha512-iHvFHPGqgJMNqXJoQpqttfsv2GI3cGodeTq4aoVLU/BT3+hXzbV0x1VpvvEhncJkDgDicJpFLM8sEPHb3b8abw==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.42.2':
+    resolution: {integrity: sha512-vPPGHjYoaGmfrU7xhfFxG7qlTBacroz5NdT+0FmDn6692D8IvpNXl1K+eV3Kag44ipJBBeR8g1HRJyx/F/9ACw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.42.2':
+    resolution: {integrity: sha512-spb7S/RUumCGyiSTg8DlrCX4bivCNmU/A1hcfkwuciTFGu8l5CDc2I6jJWWZw8/0enDGxuj5XujgXvU5tr4bxg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
   '@sentry/core@9.18.0':
     resolution: {integrity: sha512-kRVH8BqMiaU2FTHYa68zNlAloS43jl4XtIEHkLKVH/7gUtwRmM4Gqj8P7RTrZdO1Lo7ksYnGj+AG05Z09CRbOw==}
     engines: {node: '>=18'}
+
+  '@sentry/webpack-plugin@3.4.0':
+    resolution: {integrity: sha512-i+nAxxniJV5ovijojjTF5n+Yj08Xk8my+vm8+oo0C0I7xcnI2gOKft6B0sJOq01CNbo85X5m/3/edL0PKoWE9w==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      webpack: '>=4.40.0'
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -1285,6 +1415,9 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
@@ -1992,6 +2125,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -2045,6 +2182,14 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
+
+  glob@9.3.5:
+    resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -2468,12 +2613,20 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
   jsbn@1.1.0:
     resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -2492,6 +2645,11 @@ packages:
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
     hasBin: true
 
   jszip@3.10.1:
@@ -2571,8 +2729,15 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
+  magic-string@0.30.8:
+    resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
 
   map-stream@0.1.0:
@@ -2790,12 +2955,20 @@ packages:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
 
+  minimatch@8.0.4:
+    resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@4.2.8:
+    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
+    engines: {node: '>=8'}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -2845,6 +3018,15 @@ packages:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -3613,6 +3795,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tree-dump@1.0.2:
     resolution: {integrity: sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==}
     engines: {node: '>=10.0'}
@@ -3720,6 +3905,9 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unplugin@1.0.1:
+    resolution: {integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==}
+
   unrs-resolver@1.7.2:
     resolution: {integrity: sha512-BBKpaylOW8KbHsu378Zky/dGh4ckT/4NW/0SHRABdqRLcQJ2dAOjDo9g97p04sWflm0kqPqpUatxReNV/dqI5A==}
 
@@ -3748,6 +3936,10 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   vary@1.1.2:
@@ -3782,6 +3974,9 @@ packages:
     peerDependenciesMeta:
       puppeteer-core:
         optional: true
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webpack-cli@6.0.1:
     resolution: {integrity: sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==}
@@ -3827,6 +4022,9 @@ packages:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
 
+  webpack-virtual-modules@0.5.0:
+    resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
+
   webpack@5.99.8:
     resolution: {integrity: sha512-lQ3CPiSTpfOnrEGeXDwoq5hIGzSjmwD72GdfVzF7CQAI7t47rJG9eDWvcEkEn3CUQymAElVvDg3YNTlCYj+qUQ==}
     engines: {node: '>=10.13.0'}
@@ -3852,6 +4050,9 @@ packages:
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3926,6 +4127,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -3957,6 +4161,109 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.27.2': {}
+
+  '@babel/core@7.27.1':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.1
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.27.1(@babel/core@7.27.1)
+      '@babel/helpers': 7.27.1
+      '@babel/parser': 7.27.2
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.27.1
+      '@babel/types': 7.27.1
+      convert-source-map: 2.0.0
+      debug: 4.4.0
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.27.1':
+    dependencies:
+      '@babel/parser': 7.27.2
+      '@babel/types': 7.27.1
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.27.2':
+    dependencies:
+      '@babel/compat-data': 7.27.2
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.24.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.27.1
+      '@babel/types': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.27.1(@babel/core@7.27.1)':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.27.1':
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.1
+
+  '@babel/parser@7.27.2':
+    dependencies:
+      '@babel/types': 7.27.1
+
+  '@babel/template@7.27.2':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.27.2
+      '@babel/types': 7.27.1
+
+  '@babel/traverse@7.27.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.27.1
+      '@babel/parser': 7.27.2
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.1
+      debug: 4.4.0
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.27.1':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@colors/colors@1.6.0': {}
 
@@ -4280,6 +4587,8 @@ snapshots:
       '@sentry-internal/browser-utils': 9.18.0
       '@sentry/core': 9.18.0
 
+  '@sentry/babel-plugin-component-annotate@3.4.0': {}
+
   '@sentry/browser@9.18.0':
     dependencies:
       '@sentry-internal/browser-utils': 9.18.0
@@ -4288,7 +4597,71 @@ snapshots:
       '@sentry-internal/replay-canvas': 9.18.0
       '@sentry/core': 9.18.0
 
+  '@sentry/bundler-plugin-core@3.4.0':
+    dependencies:
+      '@babel/core': 7.27.1
+      '@sentry/babel-plugin-component-annotate': 3.4.0
+      '@sentry/cli': 2.42.2
+      dotenv: 16.5.0
+      find-up: 5.0.0
+      glob: 9.3.5
+      magic-string: 0.30.8
+      unplugin: 1.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.42.2':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.42.2':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.42.2':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.42.2':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.42.2':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.42.2':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.42.2':
+    optional: true
+
+  '@sentry/cli@2.42.2':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.42.2
+      '@sentry/cli-linux-arm': 2.42.2
+      '@sentry/cli-linux-arm64': 2.42.2
+      '@sentry/cli-linux-i686': 2.42.2
+      '@sentry/cli-linux-x64': 2.42.2
+      '@sentry/cli-win32-i686': 2.42.2
+      '@sentry/cli-win32-x64': 2.42.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@sentry/core@9.18.0': {}
+
+  '@sentry/webpack-plugin@3.4.0(webpack@5.99.8)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 3.4.0
+      unplugin: 1.0.1
+      uuid: 9.0.1
+      webpack: 5.99.8(webpack-cli@6.0.1)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -5209,6 +5582,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-signature@1.0.6: {}
 
   cookie-signature@1.2.2: {}
@@ -6088,6 +6463,8 @@ snapshots:
       - bare-buffer
       - supports-color
 
+  gensync@1.0.0-beta.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
@@ -6161,6 +6538,15 @@ snapshots:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  glob@9.3.5:
+    dependencies:
+      fs.realpath: 1.0.0
+      minimatch: 8.0.4
+      minipass: 4.2.8
+      path-scurry: 1.11.1
+
+  globals@11.12.0: {}
 
   globals@14.0.0: {}
 
@@ -6554,11 +6940,15 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
+  js-tokens@4.0.0: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
 
   jsbn@1.1.0: {}
+
+  jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -6573,6 +6963,8 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  json5@2.2.3: {}
 
   jszip@3.10.1:
     dependencies:
@@ -6654,7 +7046,15 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lru-cache@7.18.3: {}
+
+  magic-string@0.30.8:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   map-stream@0.1.0: {}
 
@@ -7035,11 +7435,17 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
+  minimatch@8.0.4:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
 
   minimist@1.2.8: {}
+
+  minipass@4.2.8: {}
 
   minipass@7.1.2: {}
 
@@ -7072,6 +7478,10 @@ snapshots:
       tslib: 2.8.1
 
   node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -7940,6 +8350,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tr46@0.0.3: {}
+
   tree-dump@1.0.2(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
@@ -8067,6 +8479,13 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin@1.0.1:
+    dependencies:
+      acorn: 8.14.1
+      chokidar: 3.6.0
+      webpack-sources: 3.2.3
+      webpack-virtual-modules: 0.5.0
+
   unrs-resolver@1.7.2:
     dependencies:
       napi-postinstall: 0.2.3
@@ -8108,6 +8527,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@8.3.2: {}
+
+  uuid@9.0.1: {}
 
   vary@1.1.2: {}
 
@@ -8180,6 +8601,8 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  webidl-conversions@3.0.1: {}
 
   webpack-cli@6.0.1(webpack-dev-server@5.2.1)(webpack@5.99.8):
     dependencies:
@@ -8258,6 +8681,8 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
+  webpack-virtual-modules@0.5.0: {}
+
   webpack@5.99.8(webpack-cli@6.0.1):
     dependencies:
       '@types/eslint-scope': 3.7.7
@@ -8304,6 +8729,11 @@ snapshots:
       iconv-lite: 0.6.3
 
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -8399,6 +8829,8 @@ snapshots:
   ws@8.18.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@html-eslint/parser':
         specifier: ^0.40.0
         version: 0.40.0
+      '@sentry/browser':
+        specifier: ^9.18.0
+        version: 9.18.0
       '@types/format-duration':
         specifier: ^1.0.3
         version: 1.0.3
@@ -471,6 +474,30 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@sentry-internal/browser-utils@9.18.0':
+    resolution: {integrity: sha512-TwSlmgYpHhe55JpOcVApkM0XcXZh1/cYuEPKPFgeaaPD8BrQrLJJvwKxnonSWXOhdnkJxi4GgK7j7mw57PS4aA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@9.18.0':
+    resolution: {integrity: sha512-QlrB8oQK+5bfhbgK6yHF6rLwLNJ9XuGblTc51yVkm4d4jn4W/HDyaNqMfQF+JXdTiFatl8oz2xdKR8kGK8kXyg==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@9.18.0':
+    resolution: {integrity: sha512-3DEyQLmHcYgcwJ8n8eMhI6bhhawPuMc2xTT+Az8gXMqCO/X9ZACpipAmhXFjYP9Ptl+w0Vh3nllJw+gXc/DOsg==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@9.18.0':
+    resolution: {integrity: sha512-2A32FFwrlZtdpBruvpcLEfucu6BpyqOk3F4Bo5smM/5q7u0pa7q5d9FSY5l3nwKEAFAoLGv3hcCb+8wxMm50xA==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@9.18.0':
+    resolution: {integrity: sha512-0SWfp4J2+mH4lZOcHfyIwt9VoGD7yCGQE1cm0BPcLwKnrVQeXHtUXNYNy8HTHSjTGyoFDhEAYelE/tdA3OLcWQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@9.18.0':
+    resolution: {integrity: sha512-kRVH8BqMiaU2FTHYa68zNlAloS43jl4XtIEHkLKVH/7gUtwRmM4Gqj8P7RTrZdO1Lo7ksYnGj+AG05Z09CRbOw==}
+    engines: {node: '>=18'}
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -4234,6 +4261,34 @@ snapshots:
       - supports-color
 
   '@rtsao/scc@1.1.0': {}
+
+  '@sentry-internal/browser-utils@9.18.0':
+    dependencies:
+      '@sentry/core': 9.18.0
+
+  '@sentry-internal/feedback@9.18.0':
+    dependencies:
+      '@sentry/core': 9.18.0
+
+  '@sentry-internal/replay-canvas@9.18.0':
+    dependencies:
+      '@sentry-internal/replay': 9.18.0
+      '@sentry/core': 9.18.0
+
+  '@sentry-internal/replay@9.18.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 9.18.0
+      '@sentry/core': 9.18.0
+
+  '@sentry/browser@9.18.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 9.18.0
+      '@sentry-internal/feedback': 9.18.0
+      '@sentry-internal/replay': 9.18.0
+      '@sentry-internal/replay-canvas': 9.18.0
+      '@sentry/core': 9.18.0
+
+  '@sentry/core@9.18.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 

--- a/powerup/.env
+++ b/powerup/.env
@@ -10,3 +10,8 @@ SUPPORTED_LOCALES=["en", "it"]
 
 # In production, this will come from package.json
 # VERSION=
+
+# These are only used during the production build,
+# to upload sourcemaps to Sentry.
+SENTRY_ORG="tataware"
+SENTRY_PROJECT="leaner-coffee"

--- a/powerup/.env
+++ b/powerup/.env
@@ -2,6 +2,7 @@ HOSTNAME="https://leaner-coffee.tatablack.net"
 
 SENTRY_LOADER="${SENTRY_LOADER}"
 UMAMI_LOADER="https://cloud.umami.is/script.js"
+POWERUP_LOADER="https://p.trellocdn.com/power-up.min.js"
 
 # 5 * 60 * 1000 seconds, i.e. 5 minutes
 DEFAULT_DURATION=300000

--- a/powerup/.env.development.example
+++ b/powerup/.env.development.example
@@ -4,14 +4,15 @@ PORT=8080
 
 SENTRY_LOADER="${SENTRY_LOADER}"
 UMAMI_LOADER="/assets/umami-2.18.0-debug.js"
+POWERUP_LOADER="https://p.trellocdn.com/power-up.js"
 
 # 0.5 * 60 * 1000 seconds, i.e. 30 seconds
 DEFAULT_DURATION=30000
 
-SUPPORTED_LOCALES=["en", "it"]
+SUPPORTED_LOCALES=["en","it"]
 
 # The reason for the character replacement is to make the branch name compatible with semver build metadata
-VERSION=$(git describe --always)+$(git branch --show-current | sed 's/[^0-9a-zA-Z-]/-/g')
+VERSION="$(git describe --always)+$(git branch --show-current | sed 's/[^0-9a-zA-Z-]/-/g')"
 
 # Set to true if you need to approve/reapprove a self-signed certificate
 OPEN_ON_START=false

--- a/powerup/inline/sentry_init.eta
+++ b/powerup/inline/sentry_init.eta
@@ -1,11 +1,11 @@
 <script>
     window.sentryOnLoad = function () {
-        // We need to sanitise the release name to avoid issues with Sentry. See:
+        // We need to sanitise the release name to avoid issues. See:
         // https://github.com/getsentry/relay/blob/3df33b87bbbf71d65a74e285e3a43853da5ea1d9/relay-event-schema/src/protocol/event.rs#L321-L327
         Sentry.init({
-        sendDefaultPii: false,
-        release: "<%= it.BUILDTIME_VERSION %>".replaceAll(/[^a-zA-Z0-9_.-]/g, "-"),
-        environment: "<%= it.ENVIRONMENT %>",
-      });
+            sendDefaultPii: false,
+            release: "<%= it.BUILDTIME_VERSION %>".replaceAll(/[^a-zA-Z0-9_.-]/g, "-"),
+            environment: "<%= it.ENVIRONMENT %>",
+        });
     };
 </script>

--- a/powerup/inline/umami_init.eta
+++ b/powerup/inline/umami_init.eta
@@ -4,26 +4,23 @@
     window.LeanerCoffeeAnalyticsHostname = params.get("hostname");
 
     const sanitiseUrl = (urlString) => {
-      const url = new URL(urlString);
-      return (
-        url.protocol +
-        url.hostname +
-        (url.port ? `:${url.port}` : "") +
-        url.pathname
-      );
+        const url = new URL(urlString);
+        return (
+            url.protocol +
+            url.hostname +
+            (url.port ? `:${url.port}` : "") +
+            url.pathname
+        );
     };
 
     window.LeanerCoffeeAnalyticsBeforeSend = (event, payload) => {
-      const url = sanitiseUrl(payload.url);
-      return {
-        ...payload,
-        ...{
-          referrer: window.LeanerCoffeeAnalyticsReferrer,
-
-          hostname: window.LeanerCoffeeAnalyticsHostname,
-        },
-        url,
-      };
+        const url = sanitiseUrl(payload.url);
+        return {
+            ...payload,
+            referrer: window.LeanerCoffeeAnalyticsReferrer,
+            hostname: window.LeanerCoffeeAnalyticsHostname,
+            url,
+        };
     };
 
     window.umami && window.umami.track();

--- a/powerup/package.json
+++ b/powerup/package.json
@@ -34,6 +34,7 @@
     "@html-eslint/eslint-plugin": "^0.40.0",
     "@html-eslint/parser": "^0.40.0",
     "@sentry/browser": "^9.18.0",
+    "@sentry/webpack-plugin": "^3.4.0",
     "@types/format-duration": "^1.0.3",
     "@types/node": "^22.15.3",
     "@types/umami-browser": "^2.13.0",

--- a/powerup/package.json
+++ b/powerup/package.json
@@ -33,6 +33,7 @@
     "@eslint/markdown": "^6.4.0",
     "@html-eslint/eslint-plugin": "^0.40.0",
     "@html-eslint/parser": "^0.40.0",
+    "@sentry/browser": "^9.18.0",
     "@types/format-duration": "^1.0.3",
     "@types/node": "^22.15.3",
     "@types/umami-browser": "^2.13.0",

--- a/powerup/src/LeanCoffeeBase.ts
+++ b/powerup/src/LeanCoffeeBase.ts
@@ -23,7 +23,4 @@ export class LeanCoffeeBase {
     this.cardStorage = new CardStorage();
     this.memberStorage = new MemberStorage();
   }
-
-  isRunningInProduction = (): boolean =>
-    (process.env.NODE_ENV as Environment) === "production";
 }

--- a/powerup/src/LeanCoffeeBase.ts
+++ b/powerup/src/LeanCoffeeBase.ts
@@ -2,6 +2,8 @@ import BoardStorage from "./storage/BoardStorage";
 import CardStorage from "./storage/CardStorage";
 import MemberStorage from "./storage/MemberStorage";
 import { Trello } from "./types/TrelloPowerUp";
+import { ErrorReporterInjector } from "./utils/Errors";
+import { bindAll } from "./utils/Scope";
 
 export interface LeanCoffeeBaseParams {
   w: Window;
@@ -9,6 +11,7 @@ export interface LeanCoffeeBaseParams {
   t?: Trello.PowerUp | Trello.PowerUp.IFrame;
 }
 
+@ErrorReporterInjector
 export class LeanCoffeeBase {
   w: Window;
   boardStorage: BoardStorage;
@@ -22,5 +25,6 @@ export class LeanCoffeeBase {
     this.boardStorage = new BoardStorage();
     this.cardStorage = new CardStorage();
     this.memberStorage = new MemberStorage();
+    bindAll(this);
   }
 }

--- a/powerup/src/LeanCoffeeDiscussionUI.ts
+++ b/powerup/src/LeanCoffeeDiscussionUI.ts
@@ -61,7 +61,7 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeIFrame {
     });
   }
 
-  monitorDiscussion = async (): Promise<void> => {
+  async monitorDiscussion(): Promise<void> {
     const discussionStatus = await this.cardStorage.getDiscussionStatus(this.t);
     const isOngoingOrPausedForThisCard = ["ONGOING", "PAUSED"].includes(
       discussionStatus,
@@ -116,9 +116,9 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeIFrame {
     }
 
     this.previousStatus = discussionStatus;
-  };
+  }
 
-  updateElapsed = async (status: DiscussionStatus): Promise<void> => {
+  async updateElapsed(status: DiscussionStatus): Promise<void> {
     if (status === "ONGOING") {
       const startedAt = await this.boardStorage.getDiscussionStartedAt(this.t);
       const previousElapsed =
@@ -136,9 +136,9 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeIFrame {
       this.badgeElapsed.classList.remove("ongoing");
       this.badgeElapsed.textContent = `${this.t.localizeKey("discussionElapsed")} → ${formatDuration(elapsed)}`;
     }
-  };
+  }
 
-  updateThumbs = async (): Promise<void> => {
+  async updateThumbs(): Promise<void> {
     const savedThumbs =
       (await this.cardStorage.getDiscussionThumbs(this.t)) || {};
     const currentMember = this.t.getContext().member;
@@ -160,9 +160,9 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeIFrame {
         thumbsBadge.classList.remove("own");
       }
     });
-  };
+  }
 
-  handleThumbs = async (thumb: Thumb): Promise<void> => {
+  async handleThumbs(thumb: Thumb): Promise<void> {
     const thumbs = (await this.cardStorage.getDiscussionThumbs(this.t)) || {};
     const currentMember = this.t.getContext().member;
 
@@ -181,11 +181,11 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeIFrame {
     }
 
     return this.cardStorage.saveDiscussionThumbs(this.t, thumbs);
-  };
+  }
 
-  toggleBadges = (visible: boolean): void => {
+  toggleBadges(visible: boolean): void {
     this.badges.style.display = visible ? "grid" : "none";
-  };
+  }
 
   toggleVoting = (visible: boolean): void => {
     this.voting.forEach((element) => {
@@ -193,15 +193,15 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeIFrame {
     });
   };
 
-  updateStatusHeader = (status: DiscussionStatus): void => {
+  updateStatusHeader(status: DiscussionStatus): void {
     if (status === "PAUSED") {
       this.toggleFields(".badge-header-text", "discussionUiWhatNext");
     } else {
       this.toggleFields(".badge-header-text", "discussionUiStatus");
     }
-  };
+  }
 
-  toggleFields = (cssSelector: string, key: string): void => {
+  toggleFields(cssSelector: string, key: string): void {
     const elements = this.w.document.querySelectorAll(
       cssSelector,
     ) as NodeListOf<HTMLElement>;
@@ -211,7 +211,7 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeIFrame {
 
       message.style.display = shouldBeDisplayed ? "block" : "none";
     });
-  };
+  }
 }
 
 export default LeanCoffeeDiscussionUI;

--- a/powerup/src/LeanCoffeeDiscussionUI.ts
+++ b/powerup/src/LeanCoffeeDiscussionUI.ts
@@ -1,9 +1,8 @@
 import formatDuration from "format-duration";
 
-import { LeanCoffeeBase, LeanCoffeeBaseParams } from "./LeanCoffeeBase";
-import { Trello } from "./types/TrelloPowerUp";
+import { LeanCoffeeBaseParams } from "./LeanCoffeeBase";
+import { LeanCoffeeIFrame } from "./LeanCoffeeIFrame";
 import Analytics from "./utils/Analytics";
-import { I18nConfig } from "./utils/I18nConfig";
 
 enum ThumbDirection {
   "UP" = "UP",
@@ -11,8 +10,7 @@ enum ThumbDirection {
   "MIDDLE" = "MIDDLE",
 }
 
-class LeanCoffeeDiscussionUI extends LeanCoffeeBase {
-  t: Trello.PowerUp.IFrame;
+class LeanCoffeeDiscussionUI extends LeanCoffeeIFrame {
   badges: HTMLElement;
   badgeElapsed: HTMLElement;
   badgeHeaderStatus: HTMLElement;
@@ -25,10 +23,6 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeBase {
 
   constructor({ w, config }: LeanCoffeeBaseParams) {
     super({ w, config });
-    this.t = w.TrelloPowerUp.iframe({
-      localization: I18nConfig,
-      helpfulStacks: !this.isRunningInProduction(),
-    });
 
     this.badges = this.w.document.querySelector(".badges");
     this.badgeElapsed = this.w.document.querySelector(".badge-elapsed");

--- a/powerup/src/LeanCoffeeIFrame.ts
+++ b/powerup/src/LeanCoffeeIFrame.ts
@@ -1,0 +1,31 @@
+import { LeanCoffeeBase, LeanCoffeeBaseParams } from "./LeanCoffeeBase";
+import { Trello } from "./types/TrelloPowerUp";
+import { isRunningInProduction } from "./utils/Errors";
+import { I18nConfig } from "./utils/I18nConfig";
+
+export class LeanCoffeeIFrame extends LeanCoffeeBase {
+  t: Trello.PowerUp.IFrame;
+
+  constructor({ w, config }: LeanCoffeeBaseParams) {
+    super({ w, config });
+
+    this.t = w.TrelloPowerUp.iframe({
+      localization: I18nConfig,
+      helpfulStacks: !isRunningInProduction(),
+    });
+
+    Promise.all([
+      this.boardStorage.getOrganisationIdHash(this.t),
+      this.boardStorage.getBoardIdHash(this.t),
+    ]).then(([organisationIdHash, boardIdHash]) => {
+      if (this.w.Sentry) {
+        this.w.Sentry.onLoad(async () => {
+          this.w.Sentry.setTags({
+            organisationIdHash: organisationIdHash,
+            boardIdHash: boardIdHash,
+          });
+        });
+      }
+    });
+  }
+}

--- a/powerup/src/LeanCoffeePowerUp.ts
+++ b/powerup/src/LeanCoffeePowerUp.ts
@@ -297,7 +297,7 @@ class LeanCoffeePowerUp extends LeanCoffeeBase {
   async start(): Promise<void> {
     const trelloPlugin = this.t.initialize(CapabilityHandlers(this), {
       localization: I18nConfig,
-      helpfulStacks: !this.isRunningInProduction(),
+      helpfulStacks: !isRunningInProduction(),
     }) as Trello.PowerUp.Plugin;
 
     this.discussion.init(trelloPlugin);

--- a/powerup/src/LeanCoffeeSettings.ts
+++ b/powerup/src/LeanCoffeeSettings.ts
@@ -1,20 +1,8 @@
-import { LeanCoffeeBase, LeanCoffeeBaseParams } from "./LeanCoffeeBase";
-import { Trello } from "./types/TrelloPowerUp";
+import { LeanCoffeeIFrame } from "./LeanCoffeeIFrame";
 import Debug from "./utils/Debug";
-import { I18nConfig } from "./utils/I18nConfig";
-
-class LeanCoffeeSettings extends LeanCoffeeBase {
-  t: Trello.PowerUp.IFrame;
-
-  constructor({ w, config }: LeanCoffeeBaseParams) {
-    super({ w, config });
-    this.t = w.TrelloPowerUp.iframe({
-      localization: I18nConfig,
-      helpfulStacks: !this.isRunningInProduction(),
-    });
-  }
 import { isRunningInProduction } from "./utils/Errors";
 
+class LeanCoffeeSettings extends LeanCoffeeIFrame {
   init(): void {
     if (!isRunningInProduction()) {
       (

--- a/powerup/src/LeanCoffeeSettings.ts
+++ b/powerup/src/LeanCoffeeSettings.ts
@@ -13,9 +13,10 @@ class LeanCoffeeSettings extends LeanCoffeeBase {
       helpfulStacks: !this.isRunningInProduction(),
     });
   }
+import { isRunningInProduction } from "./utils/Errors";
 
   init(): void {
-    if (!this.isRunningInProduction()) {
+    if (!isRunningInProduction()) {
       (
         this.w.document.querySelector(".dev-only") as HTMLElement
       ).style.display = "block";
@@ -35,7 +36,7 @@ class LeanCoffeeSettings extends LeanCoffeeBase {
 
   showData = async (evt: Event): Promise<void> => {
     evt.preventDefault();
-    if (this.isRunningInProduction()) {
+    if (isRunningInProduction()) {
       return;
     }
 
@@ -44,7 +45,7 @@ class LeanCoffeeSettings extends LeanCoffeeBase {
 
   wipeData = async (evt: Event): Promise<void> => {
     evt.preventDefault();
-    if (this.isRunningInProduction()) {
+    if (isRunningInProduction()) {
       return;
     }
 

--- a/powerup/src/LeanCoffeeSettings.ts
+++ b/powerup/src/LeanCoffeeSettings.ts
@@ -22,23 +22,23 @@ class LeanCoffeeSettings extends LeanCoffeeIFrame {
     });
   }
 
-  showData = async (evt: Event): Promise<void> => {
+  async showData(evt: Event): Promise<void> {
     evt.preventDefault();
     if (isRunningInProduction()) {
       return;
     }
 
     await Debug.showData(this.t);
-  };
+  }
 
-  wipeData = async (evt: Event): Promise<void> => {
+  async wipeData(evt: Event): Promise<void> {
     evt.preventDefault();
     if (isRunningInProduction()) {
       return;
     }
 
     await Debug.wipeData(this.t, this.cardStorage, this.boardStorage);
-  };
+  }
 }
 
 export default LeanCoffeeSettings;

--- a/powerup/src/badges/ElapsedCardBadge.ts
+++ b/powerup/src/badges/ElapsedCardBadge.ts
@@ -2,13 +2,17 @@ import formatDuration from "format-duration";
 
 import { Trello } from "../types/TrelloPowerUp";
 import Discussion from "../utils/Discussion";
+import { ErrorReporterInjector } from "../utils/Errors";
+import { bindAll } from "../utils/Scope";
 
-class ElapsedCardBadge implements ElapsedCardBadge {
+@ErrorReporterInjector
+class ElapsedCardBadge {
   discussion: Discussion;
 
   constructor(discussion: Discussion) {
     this.discussion = discussion;
     this.render = this.render.bind(this);
+    bindAll(this);
   }
 
   getText = async (

--- a/powerup/src/badges/VotingCardBadge.ts
+++ b/powerup/src/badges/VotingCardBadge.ts
@@ -1,8 +1,11 @@
 import BoardStorage from "../storage/BoardStorage";
 import CardStorage from "../storage/CardStorage";
 import { Trello } from "../types/TrelloPowerUp";
+import { ErrorReporterInjector } from "../utils/Errors";
+import { bindAll } from "../utils/Scope";
 import Voting from "../utils/Voting";
 
+@ErrorReporterInjector
 class VotingCardBadge {
   w: Window;
   baseUrl: string;
@@ -23,6 +26,7 @@ class VotingCardBadge {
     this.boardStorage = boardStorage;
     this.cardStorage = cardStorage;
     this.render = this.render.bind(this);
+    bindAll(this);
   }
 
   getVoters = async (t: Trello.PowerUp.IFrame): Promise<{ text: string }[]> => {

--- a/powerup/src/badges/VotingCardDetailBadge.ts
+++ b/powerup/src/badges/VotingCardDetailBadge.ts
@@ -1,6 +1,7 @@
 import VotingCardBadge from "./VotingCardBadge";
 import { Trello } from "../types/TrelloPowerUp";
 import Analytics from "../utils/Analytics";
+import { getTagsForReporting } from "../utils/Errors";
 import { I18nConfig } from "../utils/I18nConfig";
 
 class VotingCardDetailBadge extends VotingCardBadge {
@@ -22,7 +23,7 @@ class VotingCardDetailBadge extends VotingCardBadge {
 
     await t.popup({
       title: t.localizeKey("voters"),
-      url: `./voters.html?${await Analytics.getOverrides(this.boardStorage, t)}`,
+      url: `./voters.html?${await Analytics.getOverrides(this.boardStorage, t)}&${await getTagsForReporting(this.boardStorage, t)}`,
       args: {
         items,
         localization: I18nConfig,

--- a/powerup/src/popups/LeanCoffeePopupBase.ts
+++ b/powerup/src/popups/LeanCoffeePopupBase.ts
@@ -1,12 +1,14 @@
 import BoardStorage from "../storage/BoardStorage";
 import { Trello } from "../types/TrelloPowerUp";
-import { isRunningInProduction } from "../utils/Errors";
+import { ErrorReporterInjector, isRunningInProduction } from "../utils/Errors";
+import { bindAll } from "../utils/Scope";
 
 export interface LeanCoffeePopupBaseParams {
   w: Window;
 }
 
-export class LeanCoffeePopupBase {
+@ErrorReporterInjector
+class LeanCoffeePopupBase {
   w: Window;
   t: Trello.PowerUp.IFrame;
   boardStorage: BoardStorage;
@@ -17,6 +19,7 @@ export class LeanCoffeePopupBase {
       helpfulStacks: !isRunningInProduction(),
     });
     this.w = w;
+    bindAll(this);
 
     Promise.all([
       this.boardStorage.getOrganisationIdHash(this.t),
@@ -52,3 +55,5 @@ export class LeanCoffeePopupBase {
       .then(callback);
   }
 }
+
+export default LeanCoffeePopupBase;

--- a/powerup/src/popups/LeanCoffeePopupBase.ts
+++ b/powerup/src/popups/LeanCoffeePopupBase.ts
@@ -1,4 +1,5 @@
 import { Trello } from "../types/TrelloPowerUp";
+import { isRunningInProduction } from "../utils/Errors";
 
 export interface LeanCoffeePopupBaseParams {
   w: Window;
@@ -10,13 +11,10 @@ export class LeanCoffeePopupBase {
 
   constructor({ w }: LeanCoffeePopupBaseParams) {
     this.t = w.TrelloPowerUp.iframe({
-      helpfulStacks: !this.isRunningInProduction(),
+      helpfulStacks: !isRunningInProduction(),
     });
     this.w = w;
-  }
 
-  isRunningInProduction = (): boolean =>
-    (process.env.NODE_ENV as Environment) === "production";
 
   toggleFields(cssSelector: string, key: string): void {
     const elements: NodeListOf<HTMLElement> =

--- a/powerup/src/popups/LeanCoffeePopupOngoingOrPaused.ts
+++ b/powerup/src/popups/LeanCoffeePopupOngoingOrPaused.ts
@@ -1,4 +1,4 @@
-import { LeanCoffeePopupBase } from "./LeanCoffeePopupBase";
+import LeanCoffeePopupBase from "./LeanCoffeePopupBase";
 
 export class LeanCoffeePopupOngoingOrPaused extends LeanCoffeePopupBase {
   currentCardBeingDiscussed: string;
@@ -31,12 +31,12 @@ export class LeanCoffeePopupOngoingOrPaused extends LeanCoffeePopupBase {
     });
   }
 
-  onLocalised = async (): Promise<void> => {
+  async onLocalised(): Promise<void> {
     this.toggleFields(
       ".message",
       this.isRunning ? "ongoingRunning" : "ongoingOnHold",
     );
     this.t.localizeNode(document.body);
     await this.t.sizeTo("body");
-  };
+  }
 }

--- a/powerup/src/storage/Storage.ts
+++ b/powerup/src/storage/Storage.ts
@@ -1,5 +1,8 @@
 import { Trello } from "../types/TrelloPowerUp";
+import { ErrorReporterInjector } from "../utils/Errors";
+import { bindAll } from "../utils/Scope";
 
+@ErrorReporterInjector
 class Storage {
   scope: Trello.PowerUp.Scope;
   visibility: Trello.PowerUp.Visibility;
@@ -9,6 +12,7 @@ class Storage {
     visibility: Trello.PowerUp.Visibility = "private",
   ) {
     Object.assign(this, { scope, visibility });
+    bindAll(this);
   }
 
   read(

--- a/powerup/src/types/TrelloPowerUp/index.d.ts
+++ b/powerup/src/types/TrelloPowerUp/index.d.ts
@@ -1,7 +1,5 @@
 // Type definitions for the Trello PowerUp Client v1.20.9
 // Definitions by: Angelo Tata https://github.com/tatablack/
-import type { umami } from "@types/umami-browser";
-
 export namespace Trello {
   interface PowerUp {
     version: string;
@@ -659,12 +657,5 @@ declare global {
   interface Window {
     TrelloPowerUp: Trello.PowerUp;
     locale: string;
-    umami: umami.umami;
-    LeanerCoffeeAnalyticsBeforeSend: (
-      event: string,
-      payload: umami.CustomPayload,
-    ) => umami.CustomPayload;
-    LeanerCoffeeAnalyticsReferrer: string;
-    LeanerCoffeeAnalyticsHostname: string;
   }
 }

--- a/powerup/src/types/TrelloPowerUp/window.d.ts
+++ b/powerup/src/types/TrelloPowerUp/window.d.ts
@@ -1,0 +1,14 @@
+import type { umami } from "umami-browser";
+
+declare global {
+  interface Window {
+    Sentry: typeof import("@sentry/browser");
+    umami: umami.umami;
+    LeanerCoffeeAnalyticsBeforeSend: (
+      event: string,
+      payload: umami.CustomPayload,
+    ) => umami.CustomPayload;
+    LeanerCoffeeAnalyticsReferrer: string;
+    LeanerCoffeeAnalyticsHostname: string;
+  }
+}

--- a/powerup/src/utils/Errors.ts
+++ b/powerup/src/utils/Errors.ts
@@ -13,4 +13,72 @@ const getTagsForReporting = async (
 const isRunningInProduction = (): boolean =>
   (process.env.NODE_ENV as Environment) === "production";
 
-export { getTagsForReporting, isRunningInProduction };
+const isPromise = (obj: any) => !!obj && typeof obj.then === "function";
+
+const ErrorReporter = (
+  target: any,
+  methodName: string,
+  descriptor: PropertyDescriptor,
+) => {
+  const originalMethod = descriptor.value;
+  const isAsync = originalMethod.constructor.name === "AsyncFunction";
+  const warningMessage = `Leaner Coffee Power-Up: error in ${methodName} (reported)`;
+
+  if (isAsync) {
+    descriptor.value = async function (...args: any[]) {
+      try {
+        return await originalMethod.apply(this, args);
+      } catch (error) {
+        console.warn(warningMessage);
+        window.Sentry.captureException(error);
+      }
+    };
+  } else {
+    descriptor.value = function (...args: any[]) {
+      try {
+        return originalMethod.apply(this, args);
+      } catch (error) {
+        console.warn(warningMessage);
+        window.Sentry.captureException(error);
+      }
+    };
+  }
+
+  return descriptor;
+};
+
+function ErrorReporterInjector<T extends { new (...args: any[]): object }>(
+  constructor: T,
+) {
+  // Get all prototype methods
+  const prototype = constructor.prototype;
+  const methodNames = Object.getOwnPropertyNames(prototype).filter(
+    (name) => typeof prototype[name] === "function" && name !== "constructor", // Skip constructor
+  );
+
+  // Apply the ErrorReporter decorator to each method
+  methodNames.forEach((methodName) => {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, methodName);
+    if (descriptor && typeof descriptor.value === "function") {
+      const decoratedDescriptor = ErrorReporter(
+        prototype,
+        methodName,
+        descriptor,
+      );
+
+      // console.log(
+      //   `Decorating ${constructor.name}::${methodName} with ErrorReporter`,
+      // );
+      Object.defineProperty(prototype, methodName, decoratedDescriptor);
+    }
+  });
+
+  return constructor;
+}
+
+export {
+  getTagsForReporting,
+  isRunningInProduction,
+  ErrorReporter,
+  ErrorReporterInjector,
+};

--- a/powerup/src/utils/Errors.ts
+++ b/powerup/src/utils/Errors.ts
@@ -1,0 +1,4 @@
+const isRunningInProduction = (): boolean =>
+  (process.env.NODE_ENV as Environment) === "production";
+
+export { isRunningInProduction };

--- a/powerup/src/utils/Errors.ts
+++ b/powerup/src/utils/Errors.ts
@@ -1,4 +1,16 @@
+import BoardStorage from "../storage/BoardStorage";
+import { Trello } from "../types/TrelloPowerUp";
+
+const getTagsForReporting = async (
+  boardStorage: BoardStorage,
+  t: Trello.PowerUp.AnonymousHostHandlers,
+): Promise<string> => {
+  const organisationIdHash = await boardStorage.getOrganisationIdHash(t);
+  const boardIdHash = await boardStorage.getBoardIdHash(t);
+  return `organisationIdHash=${organisationIdHash}&boardIdHash=${boardIdHash}`;
+};
+
 const isRunningInProduction = (): boolean =>
   (process.env.NODE_ENV as Environment) === "production";
 
-export { isRunningInProduction };
+export { getTagsForReporting, isRunningInProduction };

--- a/powerup/src/utils/Notifications.ts
+++ b/powerup/src/utils/Notifications.ts
@@ -1,7 +1,11 @@
+import { ErrorReporterInjector } from "./Errors";
+import { bindAll } from "./Scope";
+
 export type NotificationType = {
   [key in "audio" | "text"]: string;
 };
 
+@ErrorReporterInjector
 class Notifications {
   w: Window;
   baseUrl: string;
@@ -10,6 +14,7 @@ class Notifications {
   constructor(window: Window, baseUrl: string) {
     this.w = window;
     this.baseUrl = baseUrl;
+    bindAll(this);
   }
 
   async load(url: string): Promise<AudioBufferSourceNode> {

--- a/powerup/src/utils/Scope.ts
+++ b/powerup/src/utils/Scope.ts
@@ -1,0 +1,12 @@
+const bindAll = (classInstance: any) => {
+  const p = classInstance.constructor.prototype;
+  const methodNames = Object.getOwnPropertyNames(p).filter(
+    (name) => typeof p[name] === "function" && name !== "constructor", // Skip constructor
+  );
+
+  methodNames.forEach(
+    (methodName) => (p[methodName] = p[methodName].bind(classInstance)),
+  );
+};
+
+export { bindAll };

--- a/powerup/src/utils/VersionChecker.ts
+++ b/powerup/src/utils/VersionChecker.ts
@@ -1,6 +1,7 @@
 import { parseSemVer } from "semver-parser";
 
 import Analytics from "./Analytics";
+import { getTagsForReporting } from "./Errors";
 import { I18nConfig } from "./I18nConfig";
 import BoardStorage from "../storage/BoardStorage";
 import MemberStorage from "../storage/MemberStorage";
@@ -53,7 +54,7 @@ class VersionChecker {
 
     return t.popup({
       title: title,
-      url: `./release-notes.html?${await Analytics.getOverrides(this.boardStorage, t)}`,
+      url: `./release-notes.html?${await Analytics.getOverrides(this.boardStorage, t)}&${await getTagsForReporting(this.boardStorage, t)}`,
       args: { version: __BUILDTIME_VERSION__, localization: I18nConfig },
       callback: this.storeNewVersion,
       height: 65,

--- a/powerup/src/utils/VersionChecker.ts
+++ b/powerup/src/utils/VersionChecker.ts
@@ -1,12 +1,14 @@
 import { parseSemVer } from "semver-parser";
 
 import Analytics from "./Analytics";
-import { getTagsForReporting } from "./Errors";
+import { ErrorReporterInjector, getTagsForReporting } from "./Errors";
 import { I18nConfig } from "./I18nConfig";
+import { bindAll } from "./Scope";
 import BoardStorage from "../storage/BoardStorage";
 import MemberStorage from "../storage/MemberStorage";
 import { Trello } from "../types/TrelloPowerUp";
 
+@ErrorReporterInjector
 class VersionChecker {
   boardStorage: BoardStorage;
   memberStorage: MemberStorage;
@@ -14,11 +16,10 @@ class VersionChecker {
   constructor(boardStorage: BoardStorage, memberStorage: MemberStorage) {
     this.boardStorage = boardStorage;
     this.memberStorage = memberStorage;
+    bindAll(this);
   }
 
-  isThereANewMinorOrMajor = async (
-    t: Trello.PowerUp.IFrame,
-  ): Promise<boolean> => {
+  async isThereANewMinorOrMajor(t: Trello.PowerUp.IFrame): Promise<boolean> {
     const storedVersionRaw = await this.memberStorage.read(
       t,
       MemberStorage.POWER_UP_VERSION,
@@ -36,9 +37,9 @@ class VersionChecker {
       newVersion.minor > storedVersion.minor;
 
     return !storedVersion || isNewer;
-  };
+  }
 
-  showMenu = async (t: Trello.PowerUp.IFrame): Promise<void> => {
+  async showMenu(t: Trello.PowerUp.IFrame): Promise<void> {
     const storedVersion = await this.memberStorage.read(
       t,
       MemberStorage.POWER_UP_VERSION,
@@ -59,15 +60,15 @@ class VersionChecker {
       callback: this.storeNewVersion,
       height: 65,
     });
-  };
+  }
 
-  storeNewVersion = async (t: Trello.PowerUp.IFrame): Promise<void> => {
+  async storeNewVersion(t: Trello.PowerUp.IFrame): Promise<void> {
     await this.memberStorage.write(
       t,
       MemberStorage.POWER_UP_VERSION,
       __BUILDTIME_VERSION__,
     );
-  };
+  }
 }
 
 export default VersionChecker;

--- a/powerup/src/utils/Voting.ts
+++ b/powerup/src/utils/Voting.ts
@@ -1,16 +1,18 @@
+import { ErrorReporterInjector } from "./Errors";
+import { bindAll } from "./Scope";
 import CardStorage from "../storage/CardStorage";
 import { Trello } from "../types/TrelloPowerUp";
 
+@ErrorReporterInjector
 class Voting {
   cardStorage: CardStorage;
 
   constructor() {
     this.cardStorage = new CardStorage();
+    bindAll(this);
   }
 
-  hasCurrentMemberVoted = async (
-    t: Trello.PowerUp.IFrame,
-  ): Promise<boolean> => {
+  async hasCurrentMemberVoted(t: Trello.PowerUp.IFrame): Promise<boolean> {
     const votes = await this.cardStorage.read(t, CardStorage.VOTES);
     if (!votes) {
       return false;
@@ -18,15 +20,16 @@ class Voting {
 
     const currentMember = t.getContext().member;
     return !!votes[currentMember];
-  };
+  }
 
-  getVotes = async (t: Trello.PowerUp.IFrame): Promise<Votes> =>
-    this.cardStorage.read(t, CardStorage.VOTES);
+  async getVotes(t: Trello.PowerUp.IFrame): Promise<Votes> {
+    return await this.cardStorage.read(t, CardStorage.VOTES);
+  }
 
-  countVotesByCard = async (
+  async countVotesByCard(
     t: Trello.PowerUp.IFrame,
     cardId: string,
-  ): Promise<number> => {
+  ): Promise<number> {
     const votes = await this.cardStorage.read(t, CardStorage.VOTES, cardId);
 
     if (!votes) {
@@ -34,16 +37,16 @@ class Voting {
     }
 
     return Object.keys(votes).filter((key) => votes[key]).length;
-  };
+  }
 
-  getMaxVotes = async (t: Trello.PowerUp.IFrame): Promise<number> => {
+  async getMaxVotes(t: Trello.PowerUp.IFrame): Promise<number> {
     const currentList = await t.list("cards");
 
     // https://www.talcottridge.com/multi-voting-math-or-n3
     return Math.ceil(currentList.cards.length / 3);
-  };
+  }
 
-  canCurrentMemberVote = async (t: Trello.PowerUp.IFrame): Promise<boolean> => {
+  async canCurrentMemberVote(t: Trello.PowerUp.IFrame): Promise<boolean> {
     if (await this.hasCurrentMemberVoted(t)) {
       return true;
     }
@@ -54,12 +57,12 @@ class Voting {
     const maxVotes = await this.getMaxVotes(t);
 
     return currentMemberVotes < maxVotes;
-  };
+  }
 
-  countVotesByMember = async (
+  async countVotesByMember(
     t: Trello.PowerUp.IFrame,
     cardIds: string[],
-  ): Promise<number> => {
+  ): Promise<number> {
     const listVotes: number[] = await Promise.all(
       cardIds.map(async (cardId): Promise<number> => {
         const votes = await this.cardStorage.read(t, CardStorage.VOTES, cardId);
@@ -73,7 +76,7 @@ class Voting {
     );
 
     return listVotes.reduce((total, vote): number => total + vote, 0);
-  };
+  }
 }
 
 export default Voting;

--- a/powerup/templates/_discussion-ui.eta
+++ b/powerup/templates/_discussion-ui.eta
@@ -113,7 +113,7 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+        <script src="<%= it.POWERUP_LOADER %>" crossorigin="anonymous"></script>
         <script src="@scripts/discussion-ui.ts" defer></script>
         <%~ include('inline/umami_init') %>
     </body>

--- a/powerup/templates/_discussion-ui.eta
+++ b/powerup/templates/_discussion-ui.eta
@@ -113,8 +113,8 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js"></script>
-        <script src="@scripts/discussion-ui.ts" defer="defer"></script>
+        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+        <script src="@scripts/discussion-ui.ts" defer></script>
         <%~ include('inline/umami_init') %>
     </body>
 </html>

--- a/powerup/templates/_index.eta
+++ b/powerup/templates/_index.eta
@@ -21,7 +21,7 @@
   <body>
     <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
     <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-    <script src="https://p.trellocdn.com/power-up.min.js"></script>
-    <script src="@scripts/index.ts" defer="defer"></script>
+    <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+    <script src="@scripts/index.ts" defer></script>
   </body>
 </html>

--- a/powerup/templates/_index.eta
+++ b/powerup/templates/_index.eta
@@ -21,7 +21,7 @@
   <body>
     <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
     <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-    <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+    <script src="<%= it.POWERUP_LOADER %>" crossorigin="anonymous"></script>
     <script src="@scripts/index.ts" defer></script>
   </body>
 </html>

--- a/powerup/templates/_ongoing_or_paused.eta
+++ b/powerup/templates/_ongoing_or_paused.eta
@@ -44,7 +44,7 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+        <script src="<%= it.POWERUP_LOADER %>" crossorigin="anonymous"></script>
         <script src="@scripts/popups/ongoing_or_paused.ts" defer></script>
         <%~ include('inline/umami_init') %>
     </body>

--- a/powerup/templates/_ongoing_or_paused.eta
+++ b/powerup/templates/_ongoing_or_paused.eta
@@ -44,8 +44,8 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js"></script>
-        <script src="@scripts/popups/ongoing_or_paused.ts" defer="defer"></script>
+        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+        <script src="@scripts/popups/ongoing_or_paused.ts" defer></script>
         <%~ include('inline/umami_init') %>
     </body>
 </html>

--- a/powerup/templates/_settings.eta
+++ b/powerup/templates/_settings.eta
@@ -59,8 +59,8 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js"></script>
-        <script src="@scripts/settings.ts" defer="defer"></script>
+        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+        <script src="@scripts/settings.ts" defer></script>
         <%~ include('inline/umami_init') %>
     </body>
 </html>

--- a/powerup/templates/_settings.eta
+++ b/powerup/templates/_settings.eta
@@ -59,7 +59,7 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+        <script src="<%= it.POWERUP_LOADER %>" crossorigin="anonymous"></script>
         <script src="@scripts/settings.ts" defer></script>
         <%~ include('inline/umami_init') %>
     </body>

--- a/powerup/templates/release-notes.eta
+++ b/powerup/templates/release-notes.eta
@@ -55,7 +55,7 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js"></script>
+        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
         <script>
             const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
 

--- a/powerup/templates/release-notes.eta
+++ b/powerup/templates/release-notes.eta
@@ -59,6 +59,15 @@
         <script>
             const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
 
+            if (window.Sentry) {
+                window.Sentry.onLoad(async () => {
+                    window.Sentry.setTags({
+                        organisationIdHash: t.arg("organisationIdHash"),
+                        boardIdHash: t.arg("boardIdHash"),
+                    });
+                });
+            }
+
             document.getElementById('dismiss').addEventListener('click', () => {
               window.umami && window.umami.track("updateAcknowledged");
               t.notifyParent('done');

--- a/powerup/templates/release-notes.eta
+++ b/powerup/templates/release-notes.eta
@@ -55,7 +55,7 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+        <script src="<%= it.POWERUP_LOADER %>" crossorigin="anonymous"></script>
         <script>
             const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
 

--- a/powerup/templates/release-notes.eta
+++ b/powerup/templates/release-notes.eta
@@ -57,7 +57,7 @@
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script>
-            const t = window.TrelloPowerUp.iframe();
+            const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
 
             document.getElementById('dismiss').addEventListener('click', () => {
               window.umami && window.umami.track("updateAcknowledged");

--- a/powerup/templates/too_many_votes.eta
+++ b/powerup/templates/too_many_votes.eta
@@ -39,6 +39,15 @@
         <script>
             const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
 
+            if (window.Sentry) {
+                window.Sentry.onLoad(async () => {
+                    window.Sentry.setTags({
+                        organisationIdHash: t.arg("organisationIdHash"),
+                        boardIdHash: t.arg("boardIdHash"),
+                    });
+                });
+            }
+
             const maxVotes = t.arg('maxVotes');
 
             const maxVotesElement = document.querySelector('[data-i18n-id="maxVotes"');

--- a/powerup/templates/too_many_votes.eta
+++ b/powerup/templates/too_many_votes.eta
@@ -35,7 +35,7 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js"></script>
+        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
         <script>
             const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
 

--- a/powerup/templates/too_many_votes.eta
+++ b/powerup/templates/too_many_votes.eta
@@ -35,7 +35,7 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+        <script src="<%= it.POWERUP_LOADER %>" crossorigin="anonymous"></script>
         <script>
             const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
 

--- a/powerup/templates/too_many_votes.eta
+++ b/powerup/templates/too_many_votes.eta
@@ -37,7 +37,8 @@
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script>
-            const t = window.TrelloPowerUp.iframe();
+            const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
+
             const maxVotes = t.arg('maxVotes');
 
             const maxVotesElement = document.querySelector('[data-i18n-id="maxVotes"');

--- a/powerup/templates/voters.eta
+++ b/powerup/templates/voters.eta
@@ -64,7 +64,7 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js"></script>
+        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
         <script>
             const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
 

--- a/powerup/templates/voters.eta
+++ b/powerup/templates/voters.eta
@@ -68,6 +68,15 @@
         <script>
             const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
 
+            if (window.Sentry) {
+                window.Sentry.onLoad(async () => {
+                    window.Sentry.setTags({
+                        organisationIdHash: t.arg("organisationIdHash"),
+                        boardIdHash: t.arg("boardIdHash"),
+                    });
+                });
+            }
+
             document.getElementById('clear').addEventListener('click', () => {
                 t.notifyParent('done');
                 t.closePopup();

--- a/powerup/templates/voters.eta
+++ b/powerup/templates/voters.eta
@@ -64,7 +64,7 @@
 
         <%~ include('inline/sentry_init', { BUILDTIME_VERSION, ENVIRONMENT }) %>
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
-        <script src="https://p.trellocdn.com/power-up.min.js" crossorigin="anonymous"></script>
+        <script src="<%= it.POWERUP_LOADER %>" crossorigin="anonymous"></script>
         <script>
             const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
 

--- a/powerup/templates/voters.eta
+++ b/powerup/templates/voters.eta
@@ -66,7 +66,7 @@
         <script src="<%= it.SENTRY_LOADER %>" crossorigin="anonymous"></script>
         <script src="https://p.trellocdn.com/power-up.min.js"></script>
         <script>
-            const t = window.TrelloPowerUp.iframe();
+            const t = window.TrelloPowerUp.iframe({ helpfulStacks: <% if (it.ENVIRONMENT === "development") { %>true,<% } else { %>false<% } %> });
 
             document.getElementById('clear').addEventListener('click', () => {
                 t.notifyParent('done');

--- a/powerup/tsconfig.json
+++ b/powerup/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,

--- a/powerup/webpack.common.js
+++ b/powerup/webpack.common.js
@@ -42,6 +42,7 @@ const Config = {
 const TEMPLATE_PARAMETERS = {
   SENTRY_LOADER: process.env.SENTRY_LOADER,
   UMAMI_LOADER: process.env.UMAMI_LOADER,
+  POWERUP_LOADER: process.env.POWERUP_LOADER,
   ANALYTICS_TAG: `${process.env.NODE_ENV}_${BUILDTIME_VERSION}`.substring(
     0,
     50,

--- a/powerup/webpack.common.js
+++ b/powerup/webpack.common.js
@@ -27,7 +27,9 @@ const getVersion = () => {
   return `v${currentVersion.major}.${currentVersion.minor}.${currentVersion.patch + 1}${currentVersion.pre ? `-${currentVersion.pre[0].replace("-", ".")}` : ""}${currentVersion.build.length ? `+${currentVersion.build.join(".")}` : ""}`;
 };
 
-const BUILDTIME_VERSION = isProduction ? PACKAGE_JSON.version : getVersion();
+export const BUILDTIME_VERSION = isProduction
+  ? PACKAGE_JSON.version
+  : getVersion();
 
 const Config = {
   [process.env.NODE_ENV]: {

--- a/powerup/webpack.common.js
+++ b/powerup/webpack.common.js
@@ -22,9 +22,8 @@ dotenvx.config({
 
 const isProduction = process.env.NODE_ENV === "production";
 const getVersion = () => {
-  const currentVersion = parseSemVer(process.env.VERSION);
-  console.log("Current version:", currentVersion);
-  return `v${currentVersion.major}.${currentVersion.minor}.${currentVersion.patch + 1}${currentVersion.pre ? `-${currentVersion.pre[0].replace("-", ".")}` : ""}${currentVersion.build.length ? `+${currentVersion.build.join(".")}` : ""}`;
+  const { build, major, minor, patch, pre } = parseSemVer(process.env.VERSION);
+  return `v${major}.${minor + 1}.${patch}${pre ? `-${pre[0].replace("-", ".")}` : ""}${build.length ? `+${build.join(".")}` : ""}`;
 };
 
 export const BUILDTIME_VERSION = isProduction

--- a/powerup/webpack.prod.js
+++ b/powerup/webpack.prod.js
@@ -18,6 +18,7 @@ const prod = merge(common, {
       authToken: process.env.SENTRY_AUTH_TOKEN,
       debug: true,
       release: { name: BUILDTIME_VERSION, inject: false },
+      disable: process.env.SENTRY_SOURCEMAPS_DISABLED === "true",
     }),
   ],
 

--- a/powerup/webpack.prod.js
+++ b/powerup/webpack.prod.js
@@ -17,10 +17,7 @@ const prod = merge(common, {
       project: process.env.SENTRY_PROJECT,
       authToken: process.env.SENTRY_AUTH_TOKEN,
       debug: true,
-      sourcemaps: {
-        release: { name: BUILDTIME_VERSION },
-        inject: false,
-      },
+      release: { name: BUILDTIME_VERSION, inject: false },
     }),
   ],
 

--- a/powerup/webpack.prod.js
+++ b/powerup/webpack.prod.js
@@ -1,8 +1,9 @@
+import { sentryWebpackPlugin } from "@sentry/webpack-plugin";
 import { CleanWebpackPlugin } from "clean-webpack-plugin";
 import TerserPlugin from "terser-webpack-plugin";
 import { merge } from "webpack-merge";
 
-import common from "./webpack.common.js";
+import common, { BUILDTIME_VERSION } from "./webpack.common.js";
 
 const prod = merge(common, {
   devtool: "source-map",
@@ -10,6 +11,16 @@ const prod = merge(common, {
   plugins: [
     new CleanWebpackPlugin({
       cleanOnceBeforeBuildPatterns: ["**/*", "!CNAME"],
+    }),
+    sentryWebpackPlugin({
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      debug: true,
+      sourcemaps: {
+        release: { name: BUILDTIME_VERSION },
+        inject: false,
+      },
     }),
   ],
 


### PR DESCRIPTION
There were several improvements I wanted to make, in order to make **error handling and reporting** more robust and, in general, to make the power-up easier to debug, both locally and in production.

Changes relevant for **LOCAL** troubleshooting:
- add [`helpfulStacks`](https://developer.atlassian.com/cloud/trello/guides/power-ups/topics/) wherever they were missing
- use the unminified power-up library during development

Changes relevant for **PRODUCTION** troubleshooting:
- Add more metadata to Sentry payloads, namely organisation and board id hashes in the form of Sentry tags
- Upload source maps to Sentry as part of the build process
- Wrap all of my own functions so that they will report errors to Sentry even when they're invoked as callbacks by Trello (this uses [TypeScript class decorators](https://www.typescriptlang.org/docs/handbook/decorators.html)) 