### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,54 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*'  # This will trigger for tags starting with v followed by a number
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout all history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history to determine the branch
+      - name: Check if tag is on the main branch
+        id: check-branch
+        run: |
+          BRANCH=$(git branch -r --contains ${{ github.ref }} | grep 'origin/main' || echo '')
+          if [[ -n "$BRANCH" ]]; then
+            echo "Tag is on the main branch"
+            echo "is_main_branch=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag is not on the main branch"
+            echo "is_main_branch=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Upload artifact if that is on main branch
+        if: steps.check-branch.outputs.is_main_branch == 'true'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './docs'
+      - name: Deploy to GitHub Pages
+        if: steps.check-branch.outputs.is_main_branch == 'true'
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+# There is no continuous delivery for this project.
+# In order to decide when to cut a new release, PR labels are looked at.
+# Any PR with the "release" label will trigger the workflow below,
+# which will bump the version number of the project based on another
+# label, one of major|minor|patch.
+#
+# Then the workflow will run a production build and commit the output,
+# tag the commit, and push it straight to main.
+
+name: production-build
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  release:
+    if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'release')) }}
+    runs-on: ubuntu-latest
+    name: Bump version and create a new production build
+    steps:
+      - name: Generate a token # Which will be valid only for this repo
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: "${{ secrets.RELEASER_APP_ID }}"
+          private-key: "${{ secrets.RELEASER_APP_KEY }}"
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            test-gha
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: "${{ steps.generate_token.outputs.token }}"
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.generate_token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Configure git user
+        run: |
+          git config --global user.name '${{ steps.generate_token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: package.json
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: package.json
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "store_path=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store_path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Bump version
+        run: |
+          node --version
+          pnpm --version
+          # We pull the type of version increase from the PR labels
+          operation=$(echo '${{toJSON(github.event.pull_request.labels.*.name)}}' | jq '.[] | select(. as $item | ["major", "minor", "patch"] | contains([$item]))')
+          echo "Creating a new ${operation} version"
+          cd powerup
+          new_version=$(npm version ${operation//\"/})
+          new_version_short=$(cat package.json | jq ".version")
+          git commit -m ${new_version_short//\"/}
+          git tag -a ${new_version} -m "${new_version}"
+          git push --tags https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/${{ github.repository }}.git HEAD:${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   release:
     if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'release')) }}

--- a/powerup/package.json
+++ b/powerup/package.json
@@ -8,9 +8,8 @@
     "start": "NODE_ENV=development webpack serve --config ./webpack.dev.js",
     "lint": "eslint .",
     "dist": "NODE_ENV=production webpack --config webpack.prod.js",
-    "preversion": "pnpm run lint && mkdir .git",
-    "version": "pnpm run dist && git add -A ../docs",
-    "postversion": "rmdir .git"
+    "preversion": "pnpm run lint",
+    "version": "pnpm run dist && git add -A ../docs"
   },
   "engines": {
     "node": "^20.11.0"

--- a/powerup/src/LeanCoffeePowerUp.ts
+++ b/powerup/src/LeanCoffeePowerUp.ts
@@ -8,11 +8,7 @@ import BoardStorage from "./storage/BoardStorage";
 import { Trello } from "./types/TrelloPowerUp";
 import Analytics from "./utils/Analytics";
 import Discussion from "./utils/Discussion";
-import {
-  ErrorReporterInjector,
-  getTagsForReporting,
-  isRunningInProduction,
-} from "./utils/Errors";
+import { getTagsForReporting, isRunningInProduction } from "./utils/Errors";
 import { digestMessage } from "./utils/Hashing";
 import { I18nConfig } from "./utils/I18nConfig";
 import VersionChecker from "./utils/VersionChecker";

--- a/powerup/src/utils/Errors.ts
+++ b/powerup/src/utils/Errors.ts
@@ -13,8 +13,6 @@ const getTagsForReporting = async (
 const isRunningInProduction = (): boolean =>
   (process.env.NODE_ENV as Environment) === "production";
 
-const isPromise = (obj: any) => !!obj && typeof obj.then === "function";
-
 const ErrorReporter = (
   target: any,
   methodName: string,


### PR DESCRIPTION
It's been a while that I wanted to automate this project's lifecycle.
The two workflows in this PR take care of:
- building a new version, tagging and pushing it
- deploying the new version to GitHub Pages

New versions will be built whenever a PR is merged that contains both the `release` label and one of `major`, `minor`, `patch`.