### PR TITLE
Add missing environment variable needed during build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,8 @@ jobs:
         run: pnpm install
 
       - name: Bump version
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           node --version
           pnpm --version


### PR DESCRIPTION
The build process requires a Sentry token in order to publish source maps. This wasn't configured in the repo, nor it was required in the workflow.