### PR TITLE
Relax permissions on workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   release:


### PR DESCRIPTION
I was under the impression that the token used by the workflow to push would be the one generated for the GitHub App and, as such, that the permissions declared at the top of the file weren't relevant for that token. Let's see if this understanding holds or not.