### PR TITLE
Restore workflow  permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,12 +84,12 @@ jobs:
           echo "Node.js: $(node --version)"
           echo "Pnpm: $(pnpm --version)"
           # We pull the type of version increase from the PR labels
-          operation=$(echo '${{toJSON(github.event.pull_request.labels.*.name)}}' | jq '.[] | select(. as $item | ["major", "minor", "patch"] | contains([$item]))')
-          echo "Creating a new ${operation//\"/} version"
+          bump_type=$(echo '${{toJSON(github.event.pull_request.labels.*.name)}}' | jq '.[] | select(. as $item | ["major", "minor", "patch"] | contains([$item]))' | tr -d '"')
+          echo "Creating a new ${bump_type} version"
           cd powerup
-          npm version --no-git-tag-version ${operation//\"/}
-          new_version=$(cat package.json | jq ".version")
+          npm version --no-git-tag-version ${bump_type}
+          new_version=$(cat package.json | jq ".version" | tr -d '"')
           git add ..
-          git commit -m "${new_version}"
-          git tag -a v${new_version} -m "v${new_version}"
+          git commit -m ${new_version}
+          git tag -a v${new_version} -m v${new_version}
           git push --tags https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/${{ github.repository }}.git HEAD:${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:


### PR DESCRIPTION
As I suspected, the permissions problem of the last failed deployment wasn't due to workflow permissions as such, but rather branch protection: I had forgotten to switch from classic branch protection to rulesets, and make an exception there for my releaser bot.

Changes:
- restore minimal permissions for the token in the release workflow
- ensure correct formatting of commit messages and tags (not just for cosmetic reasons: tags need to match a specific pattern in order to trigger a GitHub Pages deployment)