### PR TITLE
Fix embarrassing mistake

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           private-key: "${{ secrets.RELEASER_APP_KEY }}"
           owner: ${{ github.repository_owner }}
           repositories: |
-            test-gha
+            leaner-coffee-powerup
 
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
This is what happens when one tries to test GitHub Actions on a separate repo, to avoid polluting the main one's commit history. 