### PR TITLE
Add missing environment variable, needed to enable Sentry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Bump version
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_LOADER: ${{ secrets.SENTRY_LOADER }}
         run: |
           echo "Node.js: $(node --version)"
           echo "Pnpm: $(pnpm --version)"


### PR DESCRIPTION
Another "tiny" issue, not impacting users, but preventing the power-up to report errors to Sentry.
It may be worth reviewing my environment variables setup.