### PR TITLE
On disabling, log how long the power-up was installed for

### DIFF
--- a/powerup/src/CapabilityHandlers.ts
+++ b/powerup/src/CapabilityHandlers.ts
@@ -3,6 +3,7 @@ import BoardStorage from "./storage/BoardStorage";
 import CardStorage from "./storage/CardStorage";
 import { Trello } from "./types/TrelloPowerUp";
 import Analytics from "./utils/Analytics";
+import classifyDuration from "./utils/Duration";
 import { ErrorReporterInjector } from "./utils/Errors";
 import { I18nConfig } from "./utils/I18nConfig";
 import { bindAll } from "./utils/Scope";
@@ -187,8 +188,15 @@ class CapabilityHandlers {
 
     await Analytics.event(window, "enabled");
   }
-  async onDisable(): Promise<void> {
-    await Analytics.event(window, "disabled");
+  async onDisable(t: Trello.PowerUp.IFrame): Promise<void> {
+    const installationDate = await this.powerUp.boardStorage.read<string>(
+      t,
+      BoardStorage.POWER_UP_INSTALLATION_DATE,
+    );
+
+    await Analytics.event(window, "disabled", {
+      installedFor: classifyDuration(Date.now() - Date.parse(installationDate)),
+    });
   }
 
   async showSettings(t: Trello.PowerUp.IFrame): Promise<void> {

--- a/powerup/src/utils/Duration.ts
+++ b/powerup/src/utils/Duration.ts
@@ -1,0 +1,42 @@
+const INTERVALS = {
+  ONE_DAY: 24 * 60 * 60 * 1000,
+  ONE_WEEK: 7 * 24 * 60 * 60 * 1000,
+  ONE_MONTH: 30 * 24 * 60 * 60 * 1000,
+  SIX_MONTHS: 6 * 30 * 24 * 60 * 60 * 1000,
+  ONE_YEAR: 365 * 24 * 60 * 60 * 1000,
+  TWO_YEARS: 2 * 365 * 24 * 60 * 60 * 1000,
+  FIVE_YEARS: 5 * 365 * 24 * 60 * 60 * 1000,
+};
+
+function classifyDuration(duration: number): string {
+  switch (true) {
+    case duration < INTERVALS.ONE_DAY:
+      return "Less than a day";
+
+    case duration >= INTERVALS.ONE_DAY && duration < INTERVALS.ONE_WEEK:
+      return "Between a day and a week";
+
+    case duration >= INTERVALS.ONE_WEEK && duration < INTERVALS.ONE_MONTH:
+      return "Between a week and a month";
+
+    case duration >= INTERVALS.ONE_MONTH && duration < INTERVALS.SIX_MONTHS:
+      return "Between a month and six months";
+
+    case duration >= INTERVALS.SIX_MONTHS && duration < INTERVALS.ONE_YEAR:
+      return "Between six months and a year";
+
+    case duration >= INTERVALS.ONE_YEAR && duration < INTERVALS.TWO_YEARS:
+      return "Between one and two years";
+
+    case duration >= INTERVALS.TWO_YEARS && duration < INTERVALS.FIVE_YEARS:
+      return "Between two and five years";
+
+    case duration >= INTERVALS.FIVE_YEARS:
+      return "More than five years";
+
+    default:
+      return "Invalid duration";
+  }
+}
+
+export default classifyDuration;


### PR DESCRIPTION
I wish I had thought about storing the installation date years ago, even without analytics. Lesson learned.
At least now I will know, for new installations, how long people thought the power-up was useful for them—or if they bailed soon after installing it because it didn't meet their needs.