### PR TITLE
Fixes initialisation issue

### DIFF
--- a/powerup/i18n/en.yml
+++ b/powerup/i18n/en.yml
@@ -68,3 +68,6 @@ ongoingBottomLine: 'Click below to stop it, and start a new one on this card ins
 maxVotes: 'Based on the current number of topics in this list, you can vote for {maxVotes} of them at most.'
 maxVotesRationale: 'For the rationale, see'
 maxVotesLink: 'here'
+
+# Alerts
+notEnoughPermissions: 'You do not have the required permissions to perform this action.'

--- a/powerup/i18n/it.yml
+++ b/powerup/i18n/it.yml
@@ -67,3 +67,6 @@ ongoingBottomLine: 'Fare clic qui sotto per terminarla e iniziarne un''altra sul
 maxVotes: 'In base al numero di argomenti in questa lista, il totale dei voti a tua disposizione è {maxVotes}.'
 maxVotesRationale: 'Per le motivazioni, leggi'
 maxVotesLink: 'qui'
+
+# Alerts
+notEnoughPermissions: 'Permessi insufficienti per eseguire l''azione richiesta.'

--- a/powerup/src/CapabilityHandlers.ts
+++ b/powerup/src/CapabilityHandlers.ts
@@ -111,8 +111,8 @@ class CapabilityHandlers {
         text: t.localizeKey("clearVotesFromList"),
         callback: async (t2): Promise<void> => {
           const result = await t2.list("cards");
-          result.cards.forEach(({ id }) => {
-            this.powerUp.cardStorage.deleteMultiple(t2, [CardStorage.VOTES], id);
+          result.cards.forEach(({ id: cardId }) => {
+            this.powerUp.cardStorage.delete(t2, CardStorage.VOTES, cardId);
           });
           await Analytics.event(window, "listVotesCleared");
         },

--- a/powerup/src/LeanCoffeeDiscussionUI.ts
+++ b/powerup/src/LeanCoffeeDiscussionUI.ts
@@ -74,7 +74,7 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeIFrame {
           this.updateStatusHeader("ONGOING");
         }
 
-        this.updateElapsed("ONGOING");
+        await this.updateElapsed("ONGOING");
         break;
       }
       case "PAUSED": {
@@ -84,7 +84,7 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeIFrame {
           this.toggleVoting(true);
           this.toggleBadges(true);
           this.updateStatusHeader("PAUSED");
-          this.updateElapsed("PAUSED");
+          await this.updateElapsed("PAUSED");
         }
 
         this.updateThumbs();

--- a/powerup/src/LeanCoffeeDiscussionUI.ts
+++ b/powerup/src/LeanCoffeeDiscussionUI.ts
@@ -145,21 +145,18 @@ class LeanCoffeeDiscussionUI extends LeanCoffeeIFrame {
     const thumbs = (await this.cardStorage.read<Thumbs>(this.t, CardStorage.DISCUSSION_THUMBS)) || {};
     const currentMember = this.t.getContext().member;
 
+    let outcome: string;
+
     if (thumbs[currentMember] === thumb) {
       delete thumbs[currentMember];
-      await Analytics.event(this.w, "keepDiscussingVoted", {
-        outcome: "removed",
-        choice: thumb,
-      });
+      outcome = "removed";
     } else {
       thumbs[currentMember] = thumb;
-      await Analytics.event(this.w, "keepDiscussingVoted", {
-        outcome: "added",
-        choice: thumb,
-      });
+      outcome = "added";
     }
 
-    return this.cardStorage.write(this.t, CardStorage.DISCUSSION_THUMBS, thumbs);
+    await this.cardStorage.write(this.t, CardStorage.DISCUSSION_THUMBS, thumbs);
+    await Analytics.event(this.w, "keepDiscussingVoted", { outcome, choice: thumb });
   }
 
   toggleBadges(visible: boolean): void {

--- a/powerup/src/storage/Storage.ts
+++ b/powerup/src/storage/Storage.ts
@@ -33,6 +33,10 @@ class Storage {
     return myMembership ? myMembership.memberType : "unknown";
   }
 
+  static notEnoughPrivileges(error: any): boolean {
+    return error instanceof Error && error.message.startsWith("Scope not editable by active member");
+  }
+
   async read<T>(
     t: Trello.PowerUp.HostHandlers | Trello.PowerUp.AnonymousHostHandlers,
     key: string,
@@ -51,6 +55,10 @@ class Storage {
     } catch (error) {
       const context = t.getContext();
       const errorMessage = error instanceof Error ? error.message : error.toString();
+
+      if (Storage.notEnoughPrivileges(error)) {
+        await t.alert({ message: t.localizeKey("notEnoughPermissions") });
+      }
 
       window.Sentry.captureException(new Error("Error while editing scope: " + errorMessage), {
         contexts: {

--- a/powerup/src/utils/Debug.ts
+++ b/powerup/src/utils/Debug.ts
@@ -1,6 +1,6 @@
 import BoardStorage from "../storage/BoardStorage";
 import CardStorage from "../storage/CardStorage";
-import { Trello } from "../types/TrelloPowerUp";
+import Trello from "../types/trellopowerup/index";
 
 class Debug {
   static async showData(t: Trello.PowerUp.IFrame): Promise<void> {

--- a/powerup/src/utils/Debug.ts
+++ b/powerup/src/utils/Debug.ts
@@ -8,6 +8,9 @@ class Debug {
     console.log(JSON.stringify(t.getContext(), null, 2));
     console.groupEnd();
 
+    console.groupCollapsed("Organization");
+    console.log(JSON.stringify(await t.organization("all"), null, 2));
+    console.groupEnd();
     const boardData = await t.getAll();
     console.groupCollapsed("Board data");
     console.log(JSON.stringify(boardData, null, 2));
@@ -16,7 +19,7 @@ class Debug {
     const cards = await t.cards("id", "name");
     const cardsDataPromise = cards.map(async (card) => {
       const cardData = await t.get<any>(card.id, "shared");
-      return { name: card.name, ...cardData };
+      return { id: card.id, name: card.name, ...cardData };
     });
 
     const cardsData = await Promise.all(cardsDataPromise);

--- a/powerup/src/utils/Discussion.ts
+++ b/powerup/src/utils/Discussion.ts
@@ -131,7 +131,7 @@ class Discussion {
 
     await this.cardStorage.write(t, CardStorage.DISCUSSION_STATUS, "ENDED", cardId);
     await this.saveElapsed(t);
-    await this.cardStorage.deleteMultiple(t, [CardStorage.DISCUSSION_THUMBS], cardId);
+    await this.cardStorage.delete(t, CardStorage.DISCUSSION_THUMBS, cardId);
     await this.boardStorage.deleteMultiple(t, [
       BoardStorage.DISCUSSION_STATUS,
       BoardStorage.DISCUSSION_CARD_ID,

--- a/powerup/src/utils/Hashing.ts
+++ b/powerup/src/utils/Hashing.ts
@@ -6,3 +6,13 @@ export async function digestMessage(message: string) {
   const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join(""); // convert bytes to hex string
   return hashHex;
 }
+
+export type OrgAndBoardHashes = [org: string, board: string];
+
+export async function calculateHashes(t: Trello.PowerUp.AnonymousHostHandlers): Promise<OrgAndBoardHashes> {
+  const organisation = await t.organization("id");
+  const board = await t.board("id");
+  const organisationIdHash = await digestMessage(organisation.id);
+  const boardIdHash = await digestMessage(board.id);
+  return [organisationIdHash, boardIdHash];
+}


### PR DESCRIPTION
I wasn't particularly happy with the existing initialisation setup, as it mixed code executing when Trello decided to execute it, with code I controlled myself. Besides, the code I controlled had no access to the needed Trello functionality.

Unfortunately, I can only implement a different workaround rather than a proper solution, because I need to initialise the Power-up when it is first installed on a board, but Trello does not guarantee that their own `on-enable` handler will be called in all cases.

This PR includes:
- **initialisation refactor**: I'm moving code from my own function to a Trello handler, hijacking its purpose but, IMO, without any functional impact
- **data storage refactor**: it should now be more resilient when errors happen, report them properly, and inform the user if an error occurs due to insufficient permissions
- I sneaked in a **fix** to ensure that certain Analytics events are only sent when an operation is successful